### PR TITLE
fix: add ability to pin deps to specified version @W-8222552@

### DIFF
--- a/messages/npm.dependencies.pin.json
+++ b/messages/npm.dependencies.pin.json
@@ -1,0 +1,7 @@
+{
+  "description": "lock a list of dependencies to a target tag or default to 'latest', place these entries in 'pinnedDependencies' entry in the package.json",
+  "flags": {
+    "tag": "The name of the tag you want, e.g. 'latest-rc', or 'latest'",
+    "dryrun": "If true, will not making any changes to the package.json"
+  }
+}

--- a/src/commands/npm/dependencies/pin.ts
+++ b/src/commands/npm/dependencies/pin.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { Messages } from '@salesforce/core';
+import { ChangedPackageVersions, Package } from '../../../package';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'npm.dependencies.pin');
+
+export default class Pin extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly flagsConfig: FlagsConfig = {
+    dryrun: flags.boolean({
+      char: 'd',
+      default: false,
+      description: messages.getMessage('flags.dryrun'),
+    }),
+    tag: flags.string({
+      char: 't',
+      description: messages.getMessage('flags.tag'),
+      default: 'latest',
+    }),
+  };
+
+  public async run(): Promise<ChangedPackageVersions> {
+    const packageJson = await Package.create();
+    const pkg = packageJson.pinDependencyVersions(this.flags.tag);
+
+    if (this.flags.dryrun) {
+      process.emitWarning('Running in --dryrun mode. No changes will be written to the package.json.');
+    } else {
+      packageJson.writePackageJson();
+    }
+
+    this.ux.table(pkg, {
+      columns: [
+        { key: 'name', label: 'Name' },
+        { key: 'version', label: 'Version' },
+        { key: 'tag', label: 'Tag' },
+      ],
+    });
+
+    return pkg;
+  }
+}

--- a/test/commands/dependencies.pin.test.ts
+++ b/test/commands/dependencies.pin.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { $$, expect, test } from '@salesforce/command/lib/test';
+import * as shell from 'shelljs';
+import { fs } from '@salesforce/core';
+
+function setupStub(): void {
+  // prevent it from writing back to the package.json
+  $$.SANDBOX.stub(fs, 'writeJsonSync');
+  $$.SANDBOX.stub(fs, 'readJson').resolves({
+    name: 'test',
+    version: '1.0.0',
+    dependencies: { '@salesforce/plugin-auth': '^1.4.0' },
+    pinnedDependencies: ['@salesforce/plugin-auth'],
+  });
+  // we don't need all members of what exec returns, just the stdout
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  $$.SANDBOX.stub(shell, 'exec').returns({ stdout: '{"latest":"1.4.4","test":"0.0.6"}' });
+}
+
+describe('dependencies:pin', () => {
+  test
+    .do(() => {
+      setupStub();
+    })
+    .stdout()
+    .command(['npm:dependencies:pin', '--json'])
+    .it('should update the package.json with pinned versions for a package', (ctx) => {
+      const expected = [
+        {
+          name: '@salesforce/plugin-auth',
+          tag: 'latest',
+          version: '1.4.4',
+        },
+      ];
+
+      const result = JSON.parse(ctx.stdout).result;
+      expect(result).to.deep.equal(expected);
+    });
+
+  test
+    .do(async () => {
+      setupStub();
+    })
+    .stdout()
+    .command(['npm:dependencies:pin', '--tag', 'test', '--json'])
+    .it('should update the package.json with the target release version', (ctx) => {
+      const expected = [
+        {
+          name: '@salesforce/plugin-auth',
+          tag: 'test',
+          version: '0.0.6',
+        },
+      ];
+
+      const result = JSON.parse(ctx.stdout).result;
+      expect(result).to.deep.equal(expected);
+    });
+});


### PR DESCRIPTION
### What does this PR do?
adds the `npm:dependencies:pin` command to take entries in the `pinnedDependencies` package.json to pin them to the latest, or specified via flag, version 

```
npm:dependencies:pin                                    
Name                     Version  Tag
───────────────────────  ───────  ──────
@salesforce/core         2.15.4   latest
@salesforce/plugin-auth  1.4.5    latest
```

or when targeting a specific tag

```
npm:dependencies:pin --tag test                         
Name                     Version  Tag
───────────────────────  ───────  ──────
@salesforce/core         2.15.4   latest
@salesforce/plugin-auth  0.0.6    test
```

### What issues does this PR fix or reference?
