### PR TITLE
feat: add typescript:update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ sfdx plugins
 
 - [`sfdx circleci [-t plugin|library|orb] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-circleci--t-pluginlibraryorb---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx circleci:envvar:update -e <string> [-s <string>] [--dryrun] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-circlecienvvarupdate--e-string--s-string---dryrun---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+- [`sfdx npm:dependencies:pin [-d] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-npmdependenciespin--d--t-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx npm:lerna:release [-d] [-s <array>] [-t <string>] [-a <string>] [--install] [--githubrelease] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-npmlernarelease--d--s-array--t-string--a-string---install---githubrelease---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx npm:package:release [-d] [-s] [-t <string>] [-a <string>] [--install] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-npmpackagerelease--d--s--t-string--a-string---install---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx`](#sfdx-)
 - [`sfdx trust:fingerprint -p <string> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-trustfingerprint--p-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx trust:sign -s <string> -p <string> -k <string> [-t <string> | --tarpath <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-trustsign--s-string--p-string--k-string--t-string----tarpath-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx trust:upload -f <string> -b <string> [-k <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-trustupload--f-string--b-string--k-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+- [`sfdx typescript:update [-v <string>] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-typescriptupdate--v-string--t-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 
 ## `sfdx circleci [-t plugin|library|orb] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -95,7 +97,7 @@ EXAMPLE
   sfdx circleci -t plugin
 ```
 
-_See code: [src/commands/circleci/index.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.0.0/src/commands/circleci/index.ts)_
+_See code: [src/commands/circleci/index.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/circleci/index.ts)_
 
 ## `sfdx circleci:envvar:update -e <string> [-s <string>] [--dryrun] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -132,7 +134,32 @@ EXAMPLES
   sfdx circleci -t plugin | sfdx circleci:envvar:update -e 'MY_ENV_VAR' -e 'MY_OTHER_ENV_VAR'
 ```
 
-_See code: [src/commands/circleci/envvar/update.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.0.0/src/commands/circleci/envvar/update.ts)_
+_See code: [src/commands/circleci/envvar/update.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/circleci/envvar/update.ts)_
+
+## `sfdx npm:dependencies:pin [-d] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+
+lock a list of dependencies to a target tag or default to 'latest', place these entries in 'pinnedDependencies' entry in the package.json
+
+```
+USAGE
+  $ sfdx npm:dependencies:pin [-d] [-t <string>] [--json] [--loglevel
+  trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
+
+OPTIONS
+  -d, --dryrun                                                                      If true, will not make any changes
+                                                                                    to the package.json
+
+  -t, --tag=tag                                                                     [default: latest] The name of the
+                                                                                    tag you want, e.g. 'latest-rc', or
+                                                                                    'latest'
+
+  --json                                                                            format output as json
+
+  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for
+                                                                                    this command invocation
+```
+
+_See code: [src/commands/npm/dependencies/pin.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/npm/dependencies/pin.ts)_
 
 ## `sfdx npm:lerna:release [-d] [-s <array>] [-t <string>] [-a <string>] [--install] [--githubrelease] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -167,7 +194,7 @@ OPTIONS
                                                                                     this command invocation
 ```
 
-_See code: [src/commands/npm/lerna/release.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.0.0/src/commands/npm/lerna/release.ts)_
+_See code: [src/commands/npm/lerna/release.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/npm/lerna/release.ts)_
 
 ## `sfdx npm:package:release [-d] [-s] [-t <string>] [-a <string>] [--install] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -201,7 +228,7 @@ OPTIONS
                                                                                     this command invocation
 ```
 
-_See code: [src/commands/npm/package/release.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.0.0/src/commands/npm/package/release.ts)_
+_See code: [src/commands/npm/package/release.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/npm/package/release.ts)_
 
 ## `sfdx`
 
@@ -246,7 +273,7 @@ EXAMPLES
   sfdx repositories --json | jq -r '.result[] | select(.name=="sfdx-core") | .packages[] | .url
 ```
 
-_See code: [src/commands/repositories/index.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.0.0/src/commands/repositories/index.ts)_
+_See code: [src/commands/repositories/index.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/repositories/index.ts)_
 
 ## `sfdx trust:fingerprint -p <string> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -267,7 +294,7 @@ OPTIONS
                                                                                     this command invocation
 ```
 
-_See code: [src/commands/trust/fingerprint.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.0.0/src/commands/trust/fingerprint.ts)_
+_See code: [src/commands/trust/fingerprint.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/trust/fingerprint.ts)_
 
 ## `sfdx trust:sign -s <string> -p <string> -k <string> [-t <string> | --tarpath <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -302,7 +329,7 @@ OPTIONS
       specify the package tgz path to sign instead of generating one from the target package
 ```
 
-_See code: [src/commands/trust/sign.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.0.0/src/commands/trust/sign.ts)_
+_See code: [src/commands/trust/sign.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/trust/sign.ts)_
 
 ## `sfdx trust:upload -f <string> -b <string> [-k <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -327,6 +354,32 @@ OPTIONS
                                                                                     this command invocation
 ```
 
-_See code: [src/commands/trust/upload.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.0.0/src/commands/trust/upload.ts)_
+_See code: [src/commands/trust/upload.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/trust/upload.ts)_
+
+## `sfdx typescript:update [-v <string>] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+
+Runs tests with updated typescript version and ES target
+
+```
+USAGE
+  $ sfdx typescript:update [-v <string>] [-t <string>] [--json] [--loglevel
+  trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
+
+OPTIONS
+  -t, --target=target                                                               [default: ESNext] Specify the ES
+                                                                                    target you'd like to use. Defaults
+                                                                                    to ESNext if not specified
+
+  -v, --version=version                                                             Specify the typescript version you'd
+                                                                                    like to update to. Defaults to
+                                                                                    latest if not specified
+
+  --json                                                                            format output as json
+
+  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for
+                                                                                    this command invocation
+```
+
+_See code: [src/commands/typescript/update.ts](https://github.com/salesforcecli/plugin-release-management/blob/v1.1.2/src/commands/typescript/update.ts)_
 
 <!-- commandsstop -->

--- a/messages/npm.dependencies.pin.json
+++ b/messages/npm.dependencies.pin.json
@@ -2,6 +2,6 @@
   "description": "lock a list of dependencies to a target tag or default to 'latest', place these entries in 'pinnedDependencies' entry in the package.json",
   "flags": {
     "tag": "The name of the tag you want, e.g. 'latest-rc', or 'latest'",
-    "dryrun": "If true, will not making any changes to the package.json"
+    "dryrun": "If true, will not make any changes to the package.json"
   }
 }

--- a/messages/typescript.update.json
+++ b/messages/typescript.update.json
@@ -1,0 +1,7 @@
+{
+  "description": "Runs tests with updated typescript version and ES target",
+  "typescriptVersion": "Specify the typescript version you'd like to update to. Defaults to latest if not specified",
+  "esTarget": "Specify the ES target you'd like to use. Defaults to ESNext if not specified",
+  "InvalidTypescriptVersion": "typescript version %s does not exist",
+  "InvalidTargetVersion": "Invalid ES target: %s."
+}

--- a/src/commands/typescript/update.ts
+++ b/src/commands/typescript/update.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as path from 'path';
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { fs, Messages, SfdxError } from '@salesforce/core';
+import { exec } from 'shelljs';
+import { set } from '@salesforce/kit';
+import { asObject, getString } from '@salesforce/ts-types';
+import { NpmPackage, Package } from '../../package';
+import { SinglePackageRepo } from '../../repository';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'typescript.update');
+
+export default class Update extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly flagsConfig: FlagsConfig = {
+    version: flags.string({
+      char: 'v',
+      description: messages.getMessage('typescriptVersion'),
+      default: 'latest',
+    }),
+    target: flags.string({
+      char: 't',
+      description: messages.getMessage('esTarget'),
+      default: 'ESNext',
+    }),
+  };
+
+  private typescriptPkg: NpmPackage;
+
+  public async run(): Promise<void> {
+    this.typescriptPkg = this.retrieveTsPackage();
+    this.validateEsTarget();
+    this.validateTsVersion();
+
+    this.ux.warn('This is for testing new versions only. To update the version you must go through dev-scripts.');
+    await this.updateTsVersion();
+    await this.updateEsTarget();
+
+    const pkg = await SinglePackageRepo.create(this.ux);
+    try {
+      pkg.install();
+      pkg.build();
+      pkg.test();
+    } finally {
+      this.ux.log('Reverting unstaged stages');
+      pkg.revertUnstagedChanges();
+    }
+  }
+
+  private async updateEsTarget(): Promise<void> {
+    const tsConfigPath = path.resolve('tsconfig.json');
+    const tsConfig = await fs.readJson(tsConfigPath);
+    set(asObject(tsConfig), 'compilerOptions.target', this.flags.target);
+    this.ux.log(`Updating tsconfig target at ${tsConfigPath} to:`, this.flags.target);
+    await fs.writeJson(tsConfigPath, tsConfig);
+  }
+
+  private async updateTsVersion(): Promise<void> {
+    const newVersion = this.determineNextTsVersion();
+    this.ux.log(`Updating typescript version to ${newVersion}`);
+    const pkg = await Package.create(path.resolve('.'));
+
+    if (pkg.packageJson.devDependencies['typescript']) {
+      pkg.packageJson.devDependencies['typescript'] = newVersion;
+    }
+
+    // If the prepare script runs sf-install, the install will fail because the typescript version
+    // won't match the expected version. So in that case, we delete the prepare script so that we
+    // get a successful install
+    if (pkg.packageJson.scripts['prepare'] === 'sf-install') {
+      delete pkg.packageJson.scripts['prepare'];
+    }
+
+    pkg.writePackageJson();
+  }
+
+  private determineNextTsVersion(): string {
+    return this.flags.version === 'latest' || !this.flags.version
+      ? getString(this.typescriptPkg, 'dist-tags.latest')
+      : this.flags.version;
+  }
+
+  private retrieveTsPackage(): NpmPackage {
+    const result = exec('npm view typescript --json', { silent: true });
+    if (result.code === 0) {
+      return JSON.parse(result.stdout) as NpmPackage;
+    } else {
+      throw new SfdxError('Could not find typescript on the npm registry', 'TypescriptNotFound');
+    }
+  }
+
+  private validateEsTarget(): boolean {
+    if (this.flags.target === 'ESNext') return true;
+
+    if (/ES[0-9]{4}/g.test(this.flags.target)) return true;
+
+    throw SfdxError.create('@salesforce/plugin-release-management', 'typescript.update', 'InvalidTargetVersion', [
+      this.flags.target,
+    ]);
+  }
+
+  private validateTsVersion(): boolean {
+    if (this.flags.version === 'latest') return true;
+    if (this.flags.version && !this.typescriptPkg.versions.includes(this.flags.version)) {
+      throw SfdxError.create('@salesforce/plugin-release-management', 'typescript.update', 'InvalidTypescriptVersion', [
+        this.flags.version,
+      ]);
+    }
+    return true;
+  }
+}

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -113,6 +113,10 @@ abstract class Repository extends AsyncOptionalCreatable {
     this.execCommand('yarn build', silent);
   }
 
+  public test(): void {
+    this.execCommand('yarn test');
+  }
+
   public getBranchName(): string {
     const branch =
       this.env.getString('CIRCLE_BRANCH', null) || exec('npx git branch --show-current', { silent: true }).stdout;
@@ -394,12 +398,12 @@ export class SinglePackageRepo extends Repository {
   }
 
   private determineNextVersion(): string {
-    const versionExists = this.package.npmPackage.versions.includes(this.package.projectJson.version);
+    const versionExists = this.package.npmPackage.versions.includes(this.package.packageJson.version);
     if (!versionExists) {
       this.logger.debug(
-        `${this.package.projectJson.name}@${this.package.projectJson.version} does not exist in the registry. Assuming that it's the version we want published`
+        `${this.package.packageJson.name}@${this.package.packageJson.version} does not exist in the registry. Assuming that it's the version we want published`
       );
-      return this.package.projectJson.version;
+      return this.package.packageJson.version;
     } else {
       this.logger.debug('Using standard-version to determine next version');
       const result = this.execCommand('npx standard-version --dry-run --skip.tag --skip.commit --skip.changelog', true);

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -17,7 +17,7 @@ const $$ = testSetup();
 const pkgName = '@salesforce/my-plugin';
 
 describe('Package', () => {
-  describe('readProjectJson', () => {
+  describe('readPackageJson', () => {
     let readStub: sinon.SinonStub;
 
     beforeEach(() => {
@@ -31,7 +31,7 @@ describe('Package', () => {
 
     it('should read the package.json in the current working directory', async () => {
       const pkg = await Package.create();
-      const pJson = await pkg.readProjectJson();
+      const pJson = await pkg.readPackageJson();
       expect(pJson).to.deep.equal({
         name: pkgName,
         version: '1.0.0',
@@ -42,7 +42,7 @@ describe('Package', () => {
     it('should read the package.json in the package location', async () => {
       const packageDir = path.join('my', 'project', 'dir');
       const pkg = await Package.create(packageDir);
-      const pJson = await pkg.readProjectJson();
+      const pJson = await pkg.readPackageJson();
       expect(pJson).to.deep.equal({
         name: pkgName,
         version: '1.0.0',
@@ -53,7 +53,7 @@ describe('Package', () => {
 
   describe('validateNextVersion', () => {
     beforeEach(() => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({
           name: pkgName,
           version: '1.0.0',
@@ -93,7 +93,7 @@ describe('Package', () => {
 
   describe('get/set nextVersion', () => {
     beforeEach(() => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({
           name: pkgName,
           version: '1.0.0',
@@ -115,7 +115,7 @@ describe('Package', () => {
 
   describe('nextVersionIsAvailable', () => {
     beforeEach(() => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({
           name: pkgName,
           version: '1.0.0',

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -36,7 +36,7 @@ describe('SinglePackageRepo', () => {
     });
 
     it('should use the version in package.json if that version does not exist in the registry', async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '2.0.0' })
       );
       execStub = stubMethod($$.SANDBOX, SinglePackageRepo.prototype, 'execCommand').returns('');
@@ -45,7 +45,7 @@ describe('SinglePackageRepo', () => {
     });
 
     it('should use standard-version to determine the next version if the version in the package.json already exists', async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.0.0' })
       );
       execStub = stubMethod($$.SANDBOX, SinglePackageRepo.prototype, 'execCommand').returns('1.0.0 to 1.1.0');
@@ -56,7 +56,7 @@ describe('SinglePackageRepo', () => {
 
   describe('validate', () => {
     it('should validate that next version is valid', async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
       stubMethod($$.SANDBOX, Package.prototype, 'retrieveNpmPackage').returns({
@@ -78,7 +78,7 @@ describe('SinglePackageRepo', () => {
     });
 
     it('should invalidate the next version when it already exists', async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
       stubMethod($$.SANDBOX, Package.prototype, 'retrieveNpmPackage').returns({
@@ -102,7 +102,7 @@ describe('SinglePackageRepo', () => {
 
   describe('prepare', () => {
     beforeEach(async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
       stubMethod($$.SANDBOX, Package.prototype, 'retrieveNpmPackage').returns({
@@ -138,7 +138,7 @@ describe('SinglePackageRepo', () => {
 
   describe('sign', () => {
     beforeEach(async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
       stubMethod($$.SANDBOX, Package.prototype, 'retrieveNpmPackage').returns({
@@ -160,7 +160,7 @@ describe('SinglePackageRepo', () => {
 
   describe('verifySignature', () => {
     beforeEach(async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
       stubMethod($$.SANDBOX, Package.prototype, 'retrieveNpmPackage').returns({
@@ -183,7 +183,7 @@ describe('SinglePackageRepo', () => {
     let repo: SinglePackageRepo;
 
     beforeEach(async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
       stubMethod($$.SANDBOX, Package.prototype, 'retrieveNpmPackage').returns({
@@ -262,7 +262,7 @@ describe('LernaRepo', () => {
 
   describe('determineNextVersionByPackage', () => {
     it('should use lerna to determine the next version number', async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.0.0' })
       );
       const repo = await LernaRepo.create(uxStub);
@@ -272,7 +272,7 @@ describe('LernaRepo', () => {
 
   describe('validate', () => {
     it('should validate that next version is valid', async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
 
@@ -290,7 +290,7 @@ describe('LernaRepo', () => {
     });
 
     it('should invalidate the next version when it already exists', async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
 
@@ -310,7 +310,7 @@ describe('LernaRepo', () => {
 
   describe('prepare', () => {
     beforeEach(async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
     });
@@ -338,7 +338,7 @@ describe('LernaRepo', () => {
 
   describe('sign', () => {
     beforeEach(async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
     });
@@ -354,7 +354,7 @@ describe('LernaRepo', () => {
 
   describe('verifySignature', () => {
     beforeEach(async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
     });
@@ -370,7 +370,7 @@ describe('LernaRepo', () => {
     let repo: LernaRepo;
 
     beforeEach(async () => {
-      stubMethod($$.SANDBOX, Package.prototype, 'readProjectJson').returns(
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
       repo = await LernaRepo.create(uxStub);


### PR DESCRIPTION
### What does this PR do?
- Adds `typescript:update` command which does the following:
    - updates typescript version to latest
    - updates ES target to ESNext
    - installs dependencies
    - runs tests

- renames `ProjectJson` interface to `PackageJson`, which is more accurate

### What issues does this PR fix or reference?
@W-8667963@