### PR TITLE
feat: 🎸 @W-8712470@ add env var for target registry

### DIFF
--- a/src/commands/npm/lerna/release.ts
+++ b/src/commands/npm/lerna/release.ts
@@ -89,7 +89,7 @@ export default class Release extends SfdxCommand {
 
     if (this.flags.install) {
       lernaRepo.printStage('Install');
-      lernaRepo.install();
+      await lernaRepo.install();
 
       lernaRepo.printStage('Build');
       lernaRepo.build();

--- a/src/commands/npm/package/release.ts
+++ b/src/commands/npm/package/release.ts
@@ -75,7 +75,7 @@ export default class Release extends SfdxCommand {
 
     if (this.flags.install) {
       pkg.printStage('Install');
-      pkg.install();
+      await pkg.install();
 
       pkg.printStage('Build');
       pkg.build();

--- a/src/commands/typescript/update.ts
+++ b/src/commands/typescript/update.ts
@@ -45,7 +45,7 @@ export default class Update extends SfdxCommand {
 
     const pkg = await SinglePackageRepo.create(this.ux);
     try {
-      pkg.install();
+      await pkg.install();
       pkg.build();
       pkg.test();
     } finally {

--- a/src/package.ts
+++ b/src/package.ts
@@ -108,12 +108,12 @@ export class Package extends AsyncOptionalCreatable {
 
   public pinDependencyVersions(targetTag: string): ChangedPackageVersions {
     // get the list of dependencies to hardcode
-    if (!this.projectJson['pinnedDependencies']) {
+    if (!this.packageJson['pinnedDependencies']) {
       throw new SfdxError(
         'Pinning package dependencies requires property "pinnedDependencies" to be present in package.json'
       );
     }
-    const dependencies: string[] = this.projectJson['pinnedDependencies'];
+    const dependencies: string[] = this.packageJson['pinnedDependencies'];
     const pinnedPackages = [];
     const registry = new Registry(this.env.getString('NPM_REGISTRY', this.env.getString('NPM_TOKEN')));
     dependencies.forEach((name) => {

--- a/src/package.ts
+++ b/src/package.ts
@@ -6,7 +6,7 @@
  */
 import * as path from 'path';
 import { exec } from 'shelljs';
-import { fs, Logger } from '@salesforce/core';
+import { fs, Logger, SfdxError } from '@salesforce/core';
 import { AsyncOptionalCreatable } from '@salesforce/kit';
 import { AnyJson, get } from '@salesforce/ts-types';
 
@@ -105,6 +105,11 @@ export class Package extends AsyncOptionalCreatable {
 
   public pinDependencyVersions(targetTag: string): ChangedPackageVersions {
     // get the list of dependencies to hardcode
+    if (!this.projectJson['pinnedDependencies']) {
+      throw new SfdxError(
+        'Pinning package dependencies requires property "pinnedDependencies" to be present in package.json'
+      );
+    }
     const dependencies: string[] = this.projectJson['pinnedDependencies'];
     const pinnedPackages = [];
     dependencies.forEach((name) => {

--- a/src/package.ts
+++ b/src/package.ts
@@ -61,7 +61,7 @@ export class Package extends AsyncOptionalCreatable {
   }
 
   public retrieveNpmPackage(): NpmPackage {
-    const registry = new Registry(this.env.getString('NPM_REGISTRY', this.env.getString('NPM_TOKEN')));
+    const registry = new Registry();
     const result = exec(`npm view ${this.name} ${registry.getRegistryParameter()} --json`, { silent: true });
     return result.code === 0 ? (JSON.parse(result.stdout) as NpmPackage) : null;
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable no-underscore-dangle */
+
+import { URL } from 'url';
+import * as path from 'path';
+import * as os from 'os';
+import { exec } from 'shelljs';
+import { fs, SfdxError } from '@salesforce/core';
+import { Env } from '@salesforce/kit';
+
+export class Registry {
+  public get registryEntryLocal(): string {
+    return this._registryEntryLocal;
+  }
+
+  public get registryEntryGlobal(): string {
+    return this._registryEntryGlobal;
+  }
+
+  public get registryUrl(): string {
+    return this._registryUrl;
+  }
+
+  public get authToken(): string {
+    return this._authToken;
+  }
+  private _registryEntryLocal: string;
+  private _registryEntryGlobal: string;
+  private env: Env;
+
+  public constructor(private _registryUrl?, private _authToken?: string) {
+    this.init();
+    this.loadNpmConfigs();
+  }
+
+  /**
+   * Return a properly formatted --registry string
+   */
+  public getRegistryParameter(): string {
+    return `--registry ${this.registryUrl}`;
+  }
+
+  /**
+   * Compare this.registryUrl against npm configs and write registry entry "registry" entry to <packageDir>/.npmrc
+   * if either is not equal
+   *
+   * @param packageDirectory
+   */
+  public async setNpmRegistry(packageDirectory: string): Promise<void> {
+    if (this.registryEntryLocal !== this.registryUrl || this.registryEntryGlobal !== this.registryUrl) {
+      let npmrc: string[] = await this.readNpmrc(packageDirectory);
+      npmrc = npmrc.map((line) => {
+        if (line.includes('registry=')) {
+          if (line.endsWith(this.registryUrl)) return line;
+          return `registry=${this.registryUrl}`;
+        }
+        return line;
+      });
+      await this.writeNpmrc(packageDirectory, npmrc);
+    }
+  }
+
+  /**
+   * Examine the current npm configs to see if the registry has
+   * the authToken set.
+   * If not write the authToken to <packageDir>/.npmrc
+   *
+   * @param packageDirectory
+   */
+  public async setNpmAuth(packageDirectory: string): Promise<void> {
+    if (!this.authToken) {
+      throw new SfdxError('auth token has not been set');
+    }
+    let npmrc: string[] = await this.readNpmrc(packageDirectory);
+    const normalizedRegistry = this.normalizeRegistryUrl();
+    if (npmrc.find((line) => line.includes('_authToken'))) {
+      npmrc = npmrc.map((line) => {
+        if (line.includes('_authToken')) {
+          if (line.includes(normalizedRegistry)) return line;
+          return `${normalizedRegistry}:_authToken="${this.authToken}"${os.EOL}unsafe-perm = true`;
+        }
+        return line;
+      });
+    } else {
+      npmrc.push(`${normalizedRegistry}:_authToken="${this.authToken}"${os.EOL}unsafe-perm = true`);
+    }
+    await this.writeNpmrc(packageDirectory, npmrc);
+  }
+
+  public loadNpmConfigs(): void {
+    // check npm configs for registry
+    this._registryEntryLocal = exec('npm config get registry', { silent: true }).stdout.trim();
+    this._registryEntryGlobal = exec('npm config get registry -g', { silent: true }).stdout.trim();
+    if (!this._registryUrl) {
+      if (this._registryEntryLocal) {
+        this._registryUrl = this._registryEntryLocal;
+      } else if (this._registryEntryGlobal) {
+        this._registryUrl = this._registryEntryGlobal;
+      } else {
+        this._registryUrl = 'https://registry.npmjs.org/';
+      }
+    }
+  }
+
+  public async readNpmrc(packageDir: string): Promise<string[]> {
+    if (!(await fs.fileExists(path.join(packageDir, '.npmrc')))) {
+      return [];
+    }
+
+    const npmrc = await fs.readFile(path.join(packageDir, '.npmrc'), 'utf8');
+    return npmrc.split(os.EOL);
+  }
+
+  public async writeNpmrc(packageDir: string, npmrc: string[]): Promise<void> {
+    await fs.writeFile(path.join(packageDir, '.npmrc'), npmrc.join(os.EOL), 'utf8');
+  }
+
+  private normalizeRegistryUrl(): string {
+    const registryDomain = new URL(this._registryUrl);
+    return `//${registryDomain.host}/`;
+  }
+
+  private init(): void {
+    this.env = new Env();
+    this._registryUrl = this.env.getString('NPM_REGISTRY') ?? this.registryUrl;
+    this._authToken = this.env.getString('NPM_TOKEN') ?? this.authToken;
+  }
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-/* eslint-disable no-underscore-dangle */
-
 import { URL } from 'url';
 import * as path from 'path';
 import * as os from 'os';
@@ -15,26 +13,11 @@ import { fs, SfdxError } from '@salesforce/core';
 import { Env } from '@salesforce/kit';
 
 export class Registry {
-  public get registryEntryLocal(): string {
-    return this._registryEntryLocal;
-  }
-
-  public get registryEntryGlobal(): string {
-    return this._registryEntryGlobal;
-  }
-
-  public get registryUrl(): string {
-    return this._registryUrl;
-  }
-
-  public get authToken(): string {
-    return this._authToken;
-  }
-  private _registryEntryLocal: string;
-  private _registryEntryGlobal: string;
+  public registryEntryLocal: string;
+  public registryEntryGlobal: string;
   private env: Env;
 
-  public constructor(private _registryUrl?, private _authToken?: string) {
+  public constructor(public registryUrl?: string, public authToken?: string) {
     this.init();
     this.loadNpmConfigs();
   }
@@ -54,7 +37,7 @@ export class Registry {
    */
   public async setNpmRegistry(packageDirectory: string): Promise<void> {
     if (this.registryEntryLocal !== this.registryUrl || this.registryEntryGlobal !== this.registryUrl) {
-      let npmrc: string[] = await this.readNpmrc(packageDirectory);
+      let npmrc = await this.readNpmrc(packageDirectory);
       npmrc = npmrc.map((line) => {
         if (line.includes('registry=')) {
           if (line.endsWith(this.registryUrl)) return line;
@@ -95,15 +78,15 @@ export class Registry {
 
   public loadNpmConfigs(): void {
     // check npm configs for registry
-    this._registryEntryLocal = exec('npm config get registry', { silent: true }).stdout.trim();
-    this._registryEntryGlobal = exec('npm config get registry -g', { silent: true }).stdout.trim();
-    if (!this._registryUrl) {
-      if (this._registryEntryLocal) {
-        this._registryUrl = this._registryEntryLocal;
-      } else if (this._registryEntryGlobal) {
-        this._registryUrl = this._registryEntryGlobal;
+    this.registryEntryLocal = exec('npm config get registry', { silent: true }).stdout.trim();
+    this.registryEntryGlobal = exec('npm config get registry -g', { silent: true }).stdout.trim();
+    if (!this.registryUrl) {
+      if (this.registryEntryLocal) {
+        this.registryUrl = this.registryEntryLocal;
+      } else if (this.registryEntryGlobal) {
+        this.registryUrl = this.registryEntryGlobal;
       } else {
-        this._registryUrl = 'https://registry.npmjs.org/';
+        this.registryUrl = 'https://registry.npmjs.org/';
       }
     }
   }
@@ -122,13 +105,13 @@ export class Registry {
   }
 
   private normalizeRegistryUrl(): string {
-    const registryDomain = new URL(this._registryUrl);
+    const registryDomain = new URL(this.registryUrl);
     return `//${registryDomain.host}/`;
   }
 
   private init(): void {
     this.env = new Env();
-    this._registryUrl = this.env.getString('NPM_REGISTRY') ?? this.registryUrl;
-    this._authToken = this.env.getString('NPM_TOKEN') ?? this.authToken;
+    this.registryUrl = this.env.getString('NPM_REGISTRY') ?? this.registryUrl;
+    this.authToken = this.env.getString('NPM_TOKEN') ?? this.authToken;
   }
 }

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import { expect } from '@salesforce/command/lib/test';
+import { fs } from '@salesforce/core';
+import { shouldThrow } from '@salesforce/core/lib/testSetup';
+import { Registry } from '../src/registry';
+
+describe('registry tests', () => {
+  it('should represent defaults', () => {
+    const registry = new Registry();
+    expect(registry).to.be.ok;
+    expect(registry.registryUrl).to.include('https://registry');
+    expect(registry.getRegistryParameter()).to.be.include('--registry https://registry');
+    expect(registry.authToken).to.not.be.ok;
+  });
+  it('should represent registry https://foo.bar.baz.org', () => {
+    const registry = new Registry('https://foo.bar.baz.org');
+    expect(registry).to.be.ok;
+    expect(registry.registryUrl).to.be.equal('https://foo.bar.baz.org');
+    expect(registry.getRegistryParameter()).to.be.equal('--registry https://foo.bar.baz.org');
+    expect(registry.authToken).to.not.be.ok;
+  });
+  it('should pickup registry from env var', () => {
+    process.env.NPM_REGISTRY = 'https://foo.bar.baz.org';
+    const registry = new Registry();
+    expect(registry).to.be.ok;
+    expect(registry.registryUrl).to.be.equal('https://foo.bar.baz.org');
+    expect(registry.getRegistryParameter()).to.be.equal('--registry https://foo.bar.baz.org');
+    expect(registry.authToken).to.not.be.ok;
+    delete process.env.NPM_REGISTRY;
+  });
+});
+describe('npmrc tests', () => {
+  let packageDir;
+  beforeEach(() => {
+    packageDir = os.tmpdir();
+  });
+  afterEach(() => {
+    if (fs.fileExistsSync(path.join(packageDir, '.npmrc'))) {
+      fs.unlinkSync(path.join(packageDir, '.npmrc'));
+    }
+  });
+  it('should NOT WRITE npmrc registry for registry defaults', async () => {
+    const registry = new Registry();
+    await registry.setNpmRegistry(packageDir);
+    expect(fs.fileExistsSync(path.join(packageDir, '.npmrc'))).to.be.false;
+  });
+  it('should WRITE npmrc registry for registry not equal to default', async () => {
+    const registry = new Registry('https://foo.bar.baz.org');
+    await registry.setNpmRegistry(packageDir);
+    expect(fs.fileExistsSync(path.join(packageDir, '.npmrc'))).to.be.true;
+  });
+  it('should throw error when setting auth token when token not present', async () => {
+    const registry = new Registry();
+    try {
+      await shouldThrow(registry.setNpmAuth(packageDir));
+    } catch (e) {
+      expect(e).to.have.property('message', 'auth token has not been set');
+    }
+  });
+  it('should write token from constructor when NPM_TOKEN is not set', async () => {
+    const registry = new Registry(undefined, 'foobarbaz');
+    await registry.setNpmAuth(packageDir);
+    const npmrc = await registry.readNpmrc(packageDir);
+    expect(npmrc).to.have.lengthOf(2);
+    expect(npmrc[0]).to.be.include(':_authToken="foobarbaz"');
+    expect(npmrc[0]).to.be.include('registry');
+  });
+  it('should write token from NPM_TOKEN when constructor token not set', async () => {
+    process.env.NPM_TOKEN = 'foobarbazfoobarbaz';
+    const registry = new Registry();
+    await registry.setNpmAuth(packageDir);
+    const npmrc = await registry.readNpmrc(packageDir);
+    expect(npmrc).to.have.lengthOf(2);
+    expect(npmrc[0]).to.be.include(':_authToken="foobarbazfoobarbaz"');
+    expect(npmrc[0]).to.be.include('registry');
+    delete process.env.NPM_TOKEN;
+  });
+  it('should write token from NPM_TOKEN with private registry and undefined token in constructor', async () => {
+    process.env.NPM_TOKEN = 'foobarbazfoobarbaz';
+    const registry = new Registry('https://foo.bar.baz.org');
+    await registry.setNpmAuth(packageDir);
+    const npmrc = await registry.readNpmrc(packageDir);
+    expect(npmrc).to.have.lengthOf(2);
+    expect(npmrc[0]).to.be.include(':_authToken="foobarbazfoobarbaz"');
+    expect(npmrc[0]).to.be.include('foo.bar.baz.org');
+    delete process.env.NPM_TOKEN;
+  });
+});

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -69,6 +69,7 @@ describe('npmrc tests', () => {
     }
   });
   it('should write token from constructor when NPM_TOKEN is not set', async () => {
+    $$.SANDBOX.stub(Env.prototype, 'getString').returns(undefined);
     const registry = new Registry(undefined, 'foobarbaz');
     await registry.setNpmAuth(packageDir);
     const npmrc = await registry.readNpmrc(packageDir);

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -202,9 +202,11 @@ describe('SinglePackageRepo', () => {
     });
 
     it('should not use the --dry-run flag when the dryrun option is not provided', async () => {
+      process.env.NPM_TOKEN = 'FOOBARBAZ';
       await repo.publish();
       const cmd = execStub.firstCall.args[0];
       expect(cmd).to.not.include('--dry-run');
+      delete process.env.NPM_TOKEN;
     });
 
     it('should publish the tarfile when a signature is provided in the options', async () => {
@@ -383,9 +385,11 @@ describe('LernaRepo', () => {
     });
 
     it('should not use the --dry-run flag when the dryrun option is not provided', async () => {
+      process.env.NPM_TOKEN = 'FOOBARBAZ';
       await repo.publish();
       const cmd = execStub.lastCall.args[0];
       expect(cmd).to.not.include('--dry-run');
+      delete process.env.NPM_TOKEN;
     });
 
     it('should publish the tarfile when a signature is provided in the options', async () => {

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -192,7 +192,12 @@ describe('SinglePackageRepo', () => {
         versions: ['1.0.0'],
       });
       execStub = stubMethod($$.SANDBOX, SinglePackageRepo.prototype, 'execCommand').returns('');
+      process.env.NPM_TOKEN = 'FOOBARBAZ';
       repo = await SinglePackageRepo.create(uxStub);
+    });
+
+    afterEach(() => {
+      delete process.env.NPM_TOKEN;
     });
 
     it('should use the --dry-run flag when the dryrun option is provided', async () => {
@@ -202,11 +207,9 @@ describe('SinglePackageRepo', () => {
     });
 
     it('should not use the --dry-run flag when the dryrun option is not provided', async () => {
-      process.env.NPM_TOKEN = 'FOOBARBAZ';
       await repo.publish();
       const cmd = execStub.firstCall.args[0];
       expect(cmd).to.not.include('--dry-run');
-      delete process.env.NPM_TOKEN;
     });
 
     it('should publish the tarfile when a signature is provided in the options', async () => {
@@ -375,7 +378,12 @@ describe('LernaRepo', () => {
       stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({ name: pkgName, version: '1.1.0' })
       );
+      process.env.NPM_TOKEN = 'FOOBARBAZ';
       repo = await LernaRepo.create(uxStub);
+    });
+
+    afterEach(() => {
+      delete process.env.NPM_TOKEN;
     });
 
     it('should use the --dry-run flag when the dryrun option is provided', async () => {
@@ -385,11 +393,9 @@ describe('LernaRepo', () => {
     });
 
     it('should not use the --dry-run flag when the dryrun option is not provided', async () => {
-      process.env.NPM_TOKEN = 'FOOBARBAZ';
       await repo.publish();
       const cmd = execStub.lastCall.args[0];
       expect(cmd).to.not.include('--dry-run');
-      delete process.env.NPM_TOKEN;
     });
 
     it('should publish the tarfile when a signature is provided in the options', async () => {


### PR DESCRIPTION
Added a env var, NPM_REGISTRY, that allows users to select which npm
registry is to be used for install and publish actions.

### What does this PR do?
Gives the user the ability to direct certain actions to a specific npm registry by setting env var NPM_REGISTRY.

