### PR TITLE
fix: update @typescript-eslint packages when testing new ts version

### DIFF
--- a/src/commands/typescript/update.ts
+++ b/src/commands/typescript/update.ts
@@ -64,11 +64,13 @@ export default class Update extends SfdxCommand {
 
   private async updateTsVersion(): Promise<void> {
     const newVersion = this.determineNextTsVersion();
-    this.ux.log(`Updating typescript version to ${newVersion}`);
     const pkg = await Package.create(path.resolve('.'));
 
     if (pkg.packageJson.devDependencies['typescript']) {
+      this.ux.log(`Updating typescript version to ${newVersion}`);
       pkg.packageJson.devDependencies['typescript'] = newVersion;
+      pkg.packageJson.devDependencies['@typescript-eslint/eslint-plugin'] = 'latest';
+      pkg.packageJson.devDependencies['@typescript-eslint/parser'] = 'latest';
     }
 
     // If the prepare script runs sf-install, the install will fail because the typescript version


### PR DESCRIPTION
### What does this PR do?
Updates `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` to `latest` when testing updated version of typescript

### What issues does this PR fix or reference?
@W-8667867@