### PR TITLE
fix: throw error if git push fails

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -139,8 +139,7 @@ abstract class Repository extends AsyncOptionalCreatable {
   public pushChangesToGit(): void {
     const branch = this.getBranchName();
     const cmd = `npx git push --set-upstream --no-verify --follow-tags origin ${branch}`;
-    this.ux.log(cmd);
-    exec(cmd, { silent: false });
+    this.execCommand(cmd, false);
   }
 
   public revertUnstagedChanges(): void {


### PR DESCRIPTION
### What does this PR do?
Uses the `Repository.execCommand` method to run `git push` so that an error is thrown if it fails

### What issues does this PR fix or reference?
@W-8820867@