### PR TITLE
fix: fetch git tags before searching for latest

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -216,7 +216,7 @@ abstract class Repository extends AsyncOptionalCreatable {
     const skippableCommitTypes = ['chore', 'style', 'docs', 'ci', 'test'];
 
     // find the latest git tag so that we can get all the commits that have happened since
-    const tags = this.execCommand('git tag', true).stdout.split(os.EOL);
+    const tags = this.execCommand('git fetch --tags && git tag', true).stdout.split(os.EOL);
     const latestTag = lerna
       ? tags.find((tag) => tag.includes(`${pkg.name}@${pkg.npmPackage.version}`)) || ''
       : tags.find((tag) => tag.includes(pkg.npmPackage.version));


### PR DESCRIPTION
### What does this PR do?
Fetch git tags before searching for the latest

### What issues does this PR fix or reference?
