### PR TITLE
fix: use correct stable channel

### DIFF
--- a/src/commands/cli/versions/inspect.ts
+++ b/src/commands/cli/versions/inspect.ts
@@ -103,9 +103,9 @@ const CHANNEL_MAPPING: Record<Location, Record<Channel, Channel>> = {
   },
   [Location.ARCHIVE]: {
     [Channel.LATEST_RC]: Channel.STABLE_RC,
-    [Channel.LATEST]: Channel.STABLE_RC,
+    [Channel.LATEST]: Channel.STABLE,
     [Channel.STABLE_RC]: Channel.STABLE_RC,
-    [Channel.STABLE]: Channel.STABLE_RC,
+    [Channel.STABLE]: Channel.STABLE,
     [Channel.LEGACY]: Channel.LEGACY,
   },
 };


### PR DESCRIPTION
### What does this PR do?
Fixes `cli:versions:inspect` so that stable doesn't incorrectly download stable-rc

### What issues does this PR fix or reference?
