### PR TITLE
fix: lerna release

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -166,8 +166,12 @@ abstract class Repository extends AsyncOptionalCreatable<RepositoryOptions> {
       .stdout.split(os.EOL)
       .filter((f) => !!f);
     changedFiles.forEach((file) => {
-      exec(`git checkout -- ${file}`, { silent: false });
+      exec(`npx git checkout -- ${file}`, { silent: false });
     });
+  }
+
+  public revertAllChanges(): void {
+    exec('npx git reset --hard HEAD', { silent: true });
   }
 
   public printStage(msg: string): void {
@@ -298,20 +302,13 @@ export class LernaRepo extends Repository {
   public prepare(opts: PrepareOpts = {}): void {
     const { dryrun, githubRelease } = opts;
 
-    this.packages.forEach((pkg) => {
-      if (pkg.hasScript('version')) {
-        this.run('version', pkg.location);
-        this.stageChanges();
-      }
-    });
-
     let cmd = 'npx lerna version --conventional-commits --yes --no-commit-hooks --no-push';
     if (dryrun) cmd += ' --no-git-tag-version';
     if (!dryrun && githubRelease) cmd += ' --create-release github';
     if (!dryrun) cmd += ' --message "chore(release): publish [ci skip]"';
     this.execCommand(cmd);
     if (dryrun) {
-      this.revertUnstagedChanges();
+      this.revertAllChanges();
     }
   }
 
@@ -373,9 +370,9 @@ export class LernaRepo extends Repository {
     if (!isEmpty(nextVersions)) {
       for (const pkgPath of pkgPaths) {
         const pkg = await Package.create(pkgPath);
-        const shouldBePublihsed = await this.isReleasable(pkg, true);
+        const shouldBePublished = await this.isReleasable(pkg, true);
         const nextVersion = getString(nextVersions, `${pkg.name}.nextVersion`, null);
-        if (shouldBePublihsed && nextVersion) {
+        if (shouldBePublished && nextVersion) {
           pkg.setNextVersion(nextVersion);
           this.packages.push(pkg);
         }
@@ -419,7 +416,7 @@ export class LernaRepo extends Repository {
     this.logger.debug('determined the following version bumps:');
     this.logger.debug(result);
     // lerna modifies the package.json files so we want to reset them
-    this.revertUnstagedChanges();
+    this.revertAllChanges();
     return result;
   }
 }

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -367,12 +367,13 @@ describe('SinglePackageRepo', () => {
 describe('LernaRepo', () => {
   let uxStub: UX;
   let execStub: sinon.SinonStub;
-  let revertUnstagedChangesStub: sinon.SinonStub;
+  let revertAllChangesStub: sinon.SinonStub;
 
   beforeEach(async () => {
     uxStub = (stubInterface<UX>($$.SANDBOX, {}) as unknown) as UX;
     // if this stub doesn't exist, the test will revert all of your unstaged changes
-    revertUnstagedChangesStub = stubMethod($$.SANDBOX, LernaRepo.prototype, 'revertUnstagedChanges').returns(null);
+    stubMethod($$.SANDBOX, LernaRepo.prototype, 'revertUnstagedChanges').returns(null);
+    revertAllChangesStub = stubMethod($$.SANDBOX, LernaRepo.prototype, 'revertAllChanges').returns(null);
     stubMethod($$.SANDBOX, LernaRepo.prototype, 'getPackagePaths').returns(
       Promise.resolve([path.join('packages', 'my-plugin')])
     );
@@ -449,7 +450,7 @@ describe('LernaRepo', () => {
       expect(cmd).to.include('--no-git-tag-version');
       // We expect 2 calls to this because the first is done during the init method
       // and the second is done after doing a dryrun prepare
-      expect(revertUnstagedChangesStub.callCount).to.equal(2);
+      expect(revertAllChangesStub.callCount).to.equal(2);
     });
 
     it('should run lerna without --no-git-tag-version flag when the dryrun option is not provided', async () => {
@@ -459,7 +460,7 @@ describe('LernaRepo', () => {
       expect(cmd).to.not.include('--no-git-tag-version');
       // We expect 1 call to this because it's called during the init method.
       // it should not be called when dryrun is not provided
-      expect(revertUnstagedChangesStub.callCount).to.equal(1);
+      expect(revertAllChangesStub.callCount).to.equal(1);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Fixes `npm:lerna:release` by removing the `yarn run version` step (since lerna will run that for us anyways)

### What issues does this PR fix or reference?
[skip-validate-pr]