### PR TITLE
fix: add prerelease flag when preparing for publish

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -453,6 +453,7 @@ export class SinglePackageRepo extends Repository {
 
   public prepare(opts: PrepareOpts = {}): void {
     const { dryrun } = opts;
+    const { useprerelease } = this.options;
 
     if (this.package.hasScript('version')) {
       this.run('version');
@@ -463,6 +464,7 @@ export class SinglePackageRepo extends Repository {
       'npx standard-version --commit-all --releaseCommitMessageFormat="chore(release): {{currentTag}} [ci skip]"';
     if (dryrun) cmd += ' --dry-run';
     cmd += ` --release-as ${this.nextVersion}`;
+    if (useprerelease) cmd += ` --prelease ${useprerelease}`;
     this.execCommand(cmd);
   }
 


### PR DESCRIPTION
### What does this PR do?
Adds the `prerelease` flag to the standard-version command used during the prepare step

### What issues does this PR fix or reference?
[skip-validate-pr]