### PR TITLE
feat: add npm:release:validate command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -30,6 +30,11 @@
     "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign"]
   },
   {
+    "command": "npm:release:validate",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel", "verbose"]
+  },
+  {
     "command": "repositories",
     "plugin": "@salesforce/plugin-release-management",
     "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"]

--- a/package.json
+++ b/package.json
@@ -123,6 +123,9 @@
           },
           "package": {
             "description": "work with npm projects"
+          },
+          "release": {
+            "description": "validate npm releases"
           }
         }
       },

--- a/src/commands/npm/release/validate.ts
+++ b/src/commands/npm/release/validate.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { isMonoRepo, LernaRepo } from '../../../repository';
+import { Package } from '../../../package';
+import { CommitInspection, inspectCommits } from '../../../inspectCommits';
+
+type PackageCommits = CommitInspection & {
+  name: string;
+  currentVersion: string;
+};
+
+type Response = {
+  shouldRelease: boolean;
+  packages?: PackageCommits[];
+};
+
+export default class Validate extends SfdxCommand {
+  public static readonly description =
+    'inspects the git commits to see if there are any commits that will warrant a new release';
+  public static readonly flagsConfig: FlagsConfig = {
+    verbose: flags.builtin({
+      description: 'show all commits for all packages (only works with --json flag)',
+    }),
+  };
+
+  public async run(): Promise<Response> {
+    const isLerna = await isMonoRepo();
+    const packages = isLerna ? await LernaRepo.getPackages() : [await Package.create()];
+    const responses: PackageCommits[] = [];
+    for (const pkg of packages) {
+      const commitInspection = await inspectCommits(pkg, isLerna);
+      const response = Object.assign(commitInspection, {
+        name: pkg.name,
+        currentVersion: pkg.packageJson.version,
+      });
+      responses.push(response);
+    }
+    const shouldRelease = responses.some((resp) => !!resp.shouldRelease);
+    this.ux.log(shouldRelease.toString());
+    return this.flags.verbose ? { shouldRelease, packages: responses } : { shouldRelease };
+  }
+}

--- a/src/commands/typescript/update.ts
+++ b/src/commands/typescript/update.ts
@@ -63,7 +63,7 @@ export default class Update extends SfdxCommand {
   }
 
   private async getPackages(): Promise<Package[]> {
-    return this.repo instanceof LernaRepo ? await this.repo.getPackages() : [this.repo.package];
+    return this.repo instanceof LernaRepo ? await LernaRepo.getPackages() : [this.repo.package];
   }
 
   private async updateEsTargetConfig(packagePath: string): Promise<void> {

--- a/src/inspectCommits.ts
+++ b/src/inspectCommits.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as os from 'os';
+import { Readable } from 'stream';
+import { exec } from 'shelljs';
+import * as conventionalCommitsParser from 'conventional-commits-parser';
+import * as conventionalChangelogPresetLoader from 'conventional-changelog-preset-loader';
+import { Nullable } from '@salesforce/ts-types';
+import { Package } from './package';
+
+export interface Commit {
+  type: Nullable<string>;
+  header: Nullable<string>;
+  body: Nullable<string>;
+}
+
+export interface CommitInspection {
+  releasableCommits: Commit[];
+  unreleasableCommits: Commit[];
+  nextVersionIsHardcoded: boolean;
+  shouldRelease: boolean;
+}
+
+/**
+ * If the commit type isn't fix (patch bump), feat (minor bump), or breaking (major bump),
+ * then standard-version always defaults to a patch bump.
+ * See https://github.com/conventional-changelog/standard-version/issues/577
+ *
+ * We, however, don't want to publish a new version for chore, docs, etc. So we analyze
+ * the commits to see if any of them indicate that a new release should be published.
+ */
+export async function inspectCommits(pkg: Package, lerna = false): Promise<CommitInspection> {
+  const skippableCommitTypes = ['chore', 'style', 'docs', 'ci', 'test'];
+
+  // find the latest git tag so that we can get all the commits that have happened since
+  const tags = exec('git fetch --tags && git tag', { silent: true }).stdout.split(os.EOL);
+  const latestTag = lerna
+    ? tags.find((tag) => tag.includes(`${pkg.name}@${pkg.npmPackage.version}`)) || ''
+    : tags.find((tag) => tag.includes(pkg.npmPackage.version));
+  // import the default commit parser configuration
+  const defaultConfigPath = require.resolve('conventional-changelog-conventionalcommits');
+  const configuration = await conventionalChangelogPresetLoader({ name: defaultConfigPath });
+
+  const commits: Commit[] = await new Promise((resolve) => {
+    const DELIMITER = 'SPLIT';
+    const gitLogCommand = lerna
+      ? `git log --format=%B%n-hash-%n%H%n${DELIMITER} ${latestTag}..HEAD --no-merges -- ${pkg.location}`
+      : `git log --format=%B%n-hash-%n%H%n${DELIMITER} ${latestTag}..HEAD --no-merges`;
+    const gitLog = exec(gitLogCommand, { silent: true })
+      .stdout.split(`${DELIMITER}${os.EOL}`)
+      .filter((c) => !!c);
+    const readable = Readable.from(gitLog);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore because the type exported from conventionalCommitsParser is wrong
+    const parser = readable.pipe(conventionalCommitsParser(configuration.parserOpts));
+    const allCommits: Commit[] = [];
+    parser.on('data', (commit: Commit) => allCommits.push(commit));
+    parser.on('finish', () => resolve(allCommits));
+  });
+
+  const nextVersionIsHardcoded = pkg.nextVersionIsHardcoded();
+  // All commits are releasable if the version hardcoded in the package.json
+  // In this scenario, we want to publish regardless of the commit types
+  if (nextVersionIsHardcoded) {
+    return {
+      releasableCommits: commits,
+      unreleasableCommits: [],
+      nextVersionIsHardcoded,
+      shouldRelease: true,
+    };
+  }
+
+  const releasableCommits: Commit[] = [];
+  const unreleasableCommits: Commit[] = [];
+  for (const commit of commits) {
+    const headerIndicatesMajorChange = !!commit.header && commit.header.includes('!');
+    const bodyIndicatesMajorChange = !!commit.body && commit.body.includes('BREAKING');
+    const typeIsSkippable = skippableCommitTypes.includes(commit.type);
+    const isReleasable = !typeIsSkippable || bodyIndicatesMajorChange || headerIndicatesMajorChange;
+    if (isReleasable) {
+      releasableCommits.push(commit);
+    } else {
+      unreleasableCommits.push(commit);
+    }
+  }
+
+  return {
+    releasableCommits,
+    unreleasableCommits,
+    nextVersionIsHardcoded,
+    shouldRelease: nextVersionIsHardcoded || releasableCommits.length > 0,
+  };
+}

--- a/src/package.ts
+++ b/src/package.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as path from 'path';
-import { exec } from 'shelljs';
+import { exec, pwd } from 'shelljs';
 import { fs, Logger, SfdxError } from '@salesforce/core';
 import { AsyncOptionalCreatable } from '@salesforce/kit';
 import { AnyJson, get } from '@salesforce/ts-types';
@@ -57,9 +57,9 @@ export class Package extends AsyncOptionalCreatable {
   private nextVersion: string;
   private registry: Registry;
 
-  public constructor(location?: string) {
+  public constructor(location: string) {
     super();
-    this.location = location;
+    this.location = location || pwd().stdout;
     this.registry = new Registry();
   }
 

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -36,7 +36,7 @@ describe('Package', () => {
         name: pkgName,
         version: '1.0.0',
       });
-      expect(readStub.firstCall.calledWith('package.json')).be.true;
+      expect(readStub.firstCall.firstArg.endsWith('package.json')).be.true;
     });
 
     it('should read the package.json in the package location', async () => {

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -7,6 +7,7 @@
 
 import * as os from 'os';
 import * as path from 'path';
+import * as shelljs from 'shelljs';
 import { expect } from 'chai';
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { stubMethod, stubInterface } from '@salesforce/ts-sinon';
@@ -66,10 +67,13 @@ describe('SinglePackageRepo', () => {
 
       stubMethod($$.SANDBOX, SinglePackageRepo.prototype, 'execCommand')
         .withArgs(sinon.match('standard-version'), true)
-        .returns('1.0.0 to 1.1.0')
-        .withArgs(sinon.match('git tag'), true)
+        .returns('1.0.0 to 1.1.0');
+      stubMethod($$.SANDBOX, shelljs, 'exec')
+        .withArgs(sinon.match('npm config'))
+        .returns({ stdout: 'https://registry.npmjs.org/' })
+        .withArgs(sinon.match('git tag'), { silent: true })
         .returns({ stdout: 'v1.0.0' })
-        .withArgs(sinon.match('git log'), true)
+        .withArgs(sinon.match('git log'), { silent: true })
         .returns({ stdout: buildCommitLog('feat!', 'chore') });
       const repo = await SinglePackageRepo.create({ ux: uxStub });
       expect(repo.shouldBePublished).to.be.true;
@@ -82,10 +86,13 @@ describe('SinglePackageRepo', () => {
 
       stubMethod($$.SANDBOX, SinglePackageRepo.prototype, 'execCommand')
         .withArgs(sinon.match('standard-version'), true)
-        .returns('1.0.0 to 1.1.0')
-        .withArgs(sinon.match('git tag'), true)
+        .returns('1.0.0 to 1.1.0');
+      stubMethod($$.SANDBOX, shelljs, 'exec')
+        .withArgs(sinon.match('npm config'))
+        .returns({ stdout: 'https://registry.npmjs.org/' })
+        .withArgs(sinon.match('git tag'), { silent: true })
         .returns({ stdout: 'v1.0.0' })
-        .withArgs(sinon.match('git log'), true)
+        .withArgs(sinon.match('git log'), { silent: true })
         .returns({ stdout: buildCommitLog('feat', 'chore') });
       const repo = await SinglePackageRepo.create({ ux: uxStub });
       expect(repo.shouldBePublished).to.be.true;
@@ -98,10 +105,13 @@ describe('SinglePackageRepo', () => {
 
       stubMethod($$.SANDBOX, SinglePackageRepo.prototype, 'execCommand')
         .withArgs(sinon.match('standard-version'), true)
-        .returns('1.0.0 to 1.1.0')
-        .withArgs(sinon.match('git tag'), true)
+        .returns('1.0.0 to 1.1.0');
+      stubMethod($$.SANDBOX, shelljs, 'exec')
+        .withArgs(sinon.match('npm config'))
+        .returns({ stdout: 'https://registry.npmjs.org/' })
+        .withArgs(sinon.match('git tag'), { silent: true })
         .returns({ stdout: 'v1.0.0' })
-        .withArgs(sinon.match('git log'), true)
+        .withArgs(sinon.match('git log'), { silent: true })
         .returns({ stdout: buildCommitLog('fix', 'chore') });
       const repo = await SinglePackageRepo.create({ ux: uxStub });
       expect(repo.shouldBePublished).to.be.true;
@@ -114,10 +124,13 @@ describe('SinglePackageRepo', () => {
 
       stubMethod($$.SANDBOX, SinglePackageRepo.prototype, 'execCommand')
         .withArgs(sinon.match('standard-version'), true)
-        .returns('1.0.0 to 1.1.0')
-        .withArgs(sinon.match('git tag'), true)
+        .returns('1.0.0 to 1.1.0');
+      stubMethod($$.SANDBOX, shelljs, 'exec')
+        .withArgs(sinon.match('npm config'))
+        .returns({ stdout: 'https://registry.npmjs.org/' })
+        .withArgs(sinon.match('git tag'), { silent: true })
         .returns({ stdout: 'v1.0.0' })
-        .withArgs(sinon.match('git log'), true)
+        .withArgs(sinon.match('git log'), { silent: true })
         .returns({ stdout: buildCommitLog('chore', 'docs', 'style', 'test', 'ci') });
       const repo = await SinglePackageRepo.create({ ux: uxStub });
       expect(repo.shouldBePublished).to.be.false;
@@ -374,9 +387,7 @@ describe('LernaRepo', () => {
     // if this stub doesn't exist, the test will revert all of your unstaged changes
     stubMethod($$.SANDBOX, LernaRepo.prototype, 'revertUnstagedChanges').returns(null);
     revertAllChangesStub = stubMethod($$.SANDBOX, LernaRepo.prototype, 'revertAllChanges').returns(null);
-    stubMethod($$.SANDBOX, LernaRepo.prototype, 'getPackagePaths').returns(
-      Promise.resolve([path.join('packages', 'my-plugin')])
-    );
+    stubMethod($$.SANDBOX, LernaRepo, 'getPackagePaths').returns(Promise.resolve([path.join('packages', 'my-plugin')]));
     stubMethod($$.SANDBOX, Package.prototype, 'retrieveNpmPackage').returns({
       name: pkgName,
       version: '1.0.0',


### PR DESCRIPTION
### What does this PR do?
Adds `npm:release:validate` so that we can programmatically determine if a release should happen earlier in the build

### Usage
```
sfdx npm:release:validate
true
```

```
sfdx npm:release:validate --json
{
  status: 0,
  shouldRelease: true
}
```

```
sfdx npm:release:validate --json --verbose
{
  status: 0,
  shouldRelease: true,
  packages: [
    {
       name: '@salesforce/plugin-auth',
       currentVersion: 1.5.3,
       releaseableCommits: [ // list of commits that will warrant a new release
         { type: 'feat', body: 'add a new feature' }
       ],
       unreleaseableCommits: [], // list of commits that do not warrant a new release
       shouldRelease: true
    }
  ]
}
```

### What issues does this PR fix or reference?
@W-9234354@