### PR TITLE
fix: lerna publish to use correct default package dir [skip-validate-pr]

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -395,7 +395,9 @@ export class LernaRepo extends Repository {
   private async getPackagePaths(): Promise<string[]> {
     const workingDir = pwd().stdout;
     const lernaJson = (await fs.readJson('lerna.json')) as LernaJson;
-    const packageGlobs = lernaJson.packages || ['*'];
+    // https://github.com/lerna/lerna#lernajson
+    // "By default, lerna initializes the packages list as ["packages/*"]"
+    const packageGlobs = lernaJson.packages || ['packages/*'];
     const packages = packageGlobs
       .map((pGlob) => glob.sync(pGlob))
       .reduce((x, y) => x.concat(y), [])


### PR DESCRIPTION
### What does this PR do?
Lerna publish will fail if it doesn't define the `packages` property in the lerna.json. It should provide the right default so it works without this value.

### What issues does this PR fix or reference?
N/A