### PR TITLE
feat: add command for consolidating dependabot PRs

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,57 +1,147 @@
 [
-  {
-    "command": "circleci",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["contains-package-type", "json", "loglevel"]
-  },
-  {
-    "command": "circleci:envvar:update",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
-  },
-  {
-    "command": "cli:versions:inspect",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["channels", "dependencies", "json", "locations", "loglevel", "salesforce"]
-  },
-  {
-    "command": "npm:dependencies:pin",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "tag"]
-  },
-  {
-    "command": "npm:lerna:release",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign"]
-  },
-  {
-    "command": "npm:package:release",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign"]
-  },
-  {
-    "command": "npm:release:validate",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "verbose"]
-  },
-  {
-    "command": "repositories",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"]
-  },
-  {
-    "command": "trust:sign",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "privatekeypath", "publickeyurl", "signatureurl", "target", "tarpath"]
-  },
-  {
-    "command": "trust:upload",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["bucket", "json", "keyprefix", "loglevel", "signature"]
-  },
-  {
-    "command": "typescript:update",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "target", "version"]
-  }
+    {
+        "command": "circleci",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "contains-package-type",
+            "json",
+            "loglevel"
+        ]
+    },
+    {
+        "command": "circleci:envvar:update",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "envvar",
+            "json",
+            "loglevel",
+            "slug"
+        ]
+    },
+    {
+        "command": "cli:versions:inspect",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "channels",
+            "dependencies",
+            "json",
+            "locations",
+            "loglevel",
+            "salesforce"
+        ]
+    },
+    {
+        "command": "dependabot:consolidate",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "base-branch",
+            "dryrun",
+            "ignore",
+            "json",
+            "loglevel",
+            "max-version-bump",
+            "no-pr",
+            "owner",
+            "repo",
+            "target-branch"
+        ]
+    },
+    {
+        "command": "npm:dependencies:pin",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "tag"
+        ]
+    },
+    {
+        "command": "npm:lerna:release",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "githubrelease",
+            "install",
+            "json",
+            "loglevel",
+            "npmaccess",
+            "npmtag",
+            "sign"
+        ]
+    },
+    {
+        "command": "npm:package:release",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "install",
+            "json",
+            "loglevel",
+            "npmaccess",
+            "npmtag",
+            "prerelease",
+            "sign"
+        ]
+    },
+    {
+        "command": "npm:release:validate",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "verbose"
+        ]
+    },
+    {
+        "command": "repositories",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "columns",
+            "csv",
+            "extended",
+            "filter",
+            "json",
+            "loglevel",
+            "no-header",
+            "no-truncate",
+            "output",
+            "sort"
+        ]
+    },
+    {
+        "command": "trust:sign",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "privatekeypath",
+            "publickeyurl",
+            "signatureurl",
+            "target",
+            "tarpath"
+        ]
+    },
+    {
+        "command": "trust:upload",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "bucket",
+            "json",
+            "keyprefix",
+            "loglevel",
+            "signature"
+        ]
+    },
+    {
+        "command": "typescript:update",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "target",
+            "version"
+        ]
+    }
 ]

--- a/messages/dependabot.consolidate.json
+++ b/messages/dependabot.consolidate.json
@@ -1,0 +1,16 @@
+{
+  "description": "consolidate dependabot PRs into a single PR",
+  "maxVersionBump": "the maximum version bump you want to be included",
+  "dryrun": "only show what would happen if you consolidated dependabot PRs",
+  "baseBranch": "name of the base branch for merging",
+  "targetBranch": "name of the target branch for merging",
+  "noPR": "do everything but create the PR",
+  "ignore": "ignore any PRs with titles that include this value",
+  "owner": "the organization that the repository belongs to. This defaults to the owner specified in the package.json",
+  "repo": "the repository you want to consolidate PRs on. This defaults to the repository specified in the package.json",
+  "examples": [
+    "<%= config.bin %> <%= command.id %> --max-version-bump patch",
+    "<%= config.bin %> <%= command.id %> --max-version-bump minor",
+    "<%= config.bin %> <%= command.id %> --max-version-bump major"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@oclif/config": "^1",
+    "@octokit/core": "^3.4.0",
     "@salesforce/command": "^3.0.5",
     "@salesforce/core": "^2.23.2",
     "@salesforce/kit": "^1.3.3",
@@ -25,6 +26,7 @@
     "got": "^11.8.0",
     "proxy-agent": "^4.0.1",
     "proxy-from-env": "^1.1.0",
+    "semver": "^7.3.5",
     "shelljs": "^0.8.4",
     "standard-version": "^9.0.0",
     "tslib": "^2"
@@ -40,6 +42,7 @@
     "@salesforce/ts-sinon": "1.3.12",
     "@types/conventional-changelog-preset-loader": "^2.3.1",
     "@types/conventional-commits-parser": "^3.0.1",
+    "@types/semver": "^7.3.6",
     "@types/shelljs": "^0.8.8",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,9 @@
           }
         }
       },
+      "dependabot": {
+        "description": "interact with dependabot PRs"
+      },
       "npm": {
         "description": "release npm packages",
         "subtopics": {

--- a/src/commands/dependabot/consolidate.ts
+++ b/src/commands/dependabot/consolidate.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as os from 'os';
+import { fs, Messages } from '@salesforce/core';
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { Octokit } from '@octokit/core';
+import { Env } from '@salesforce/kit';
+import { diff, ReleaseType } from 'semver';
+import { bold, cyan, green } from 'chalk';
+import { exec } from 'shelljs';
+import { ensureString, isString } from '@salesforce/ts-types';
+import { PackageJson } from '../../package';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'dependabot.consolidate');
+
+export type BumpType = Extract<ReleaseType, 'major' | 'minor' | 'patch'>;
+
+export default class Consolidate extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly flagsConfig: FlagsConfig = {
+    'max-version-bump': flags.enum({
+      description: messages.getMessage('maxVersionBump'),
+      char: 'm',
+      options: ['major', 'minor', 'patch'],
+      default: 'minor',
+      required: true,
+    }),
+    'base-branch': flags.string({
+      description: messages.getMessage('baseBranch'),
+      char: 'b',
+      default: 'main',
+      required: true,
+    }),
+    'target-branch': flags.string({
+      description: messages.getMessage('targetBranch'),
+      char: 't',
+      default: 'consolidate-dependabot',
+      required: true,
+    }),
+    ignore: flags.array({
+      description: messages.getMessage('ignore'),
+      default: [],
+    }),
+    dryrun: flags.boolean({
+      description: messages.getMessage('dryrun'),
+      char: 'd',
+      default: false,
+    }),
+    'no-pr': flags.boolean({
+      description: messages.getMessage('noPR'),
+      default: false,
+    }),
+    owner: flags.string({
+      description: messages.getMessage('owner'),
+      char: 'o',
+    }),
+    repo: flags.string({
+      description: messages.getMessage('repo'),
+      char: 'r',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { owner, repo } = await this.getOwnerAndRepo();
+    const baseBranch = ensureString(this.flags['base-branch']);
+    const targetBranch = ensureString(this.flags['target-branch']);
+    const auth = ensureString(new Env().getString('GH_TOKEN'), 'GH_TOKEN is required to be set in the environment');
+
+    const octokit = new Octokit({ auth });
+    const pullRequests = await octokit.request('GET /repos/{owner}/{repo}/pulls', {
+      owner,
+      repo,
+    });
+
+    const dependabotPRs = pullRequests.data.filter(
+      (d) =>
+        d.state === 'open' &&
+        d.user.login === 'dependabot[bot]' &&
+        this.meetsVersionCriteria(d.title) &&
+        !this.shouldBeIgnored(d.title)
+    );
+
+    let prBody = `This PR consolidates all dependabot PRs that are less than or equal to a ${
+      this.flags['max-version-bump'] as string
+    } version bump${os.EOL}${os.EOL}`;
+    for (const pr of dependabotPRs) {
+      prBody += `Closes #${pr.number}${os.EOL}`;
+    }
+
+    const prTitle = `Consolidate ${this.flags['max-version-bump'] as string} dependabot PRs`;
+
+    this.log(bold('PR Title:'));
+    this.log(prTitle);
+    this.log(bold('PR Body:'));
+    this.log(prBody);
+
+    this.log(bold('Commits:'));
+    for (const pr of dependabotPRs) {
+      this.log(`  ${cyan(pr.head.sha)} [#${pr.number} ${pr.title}]`);
+    }
+
+    if (!this.flags.dryrun) {
+      try {
+        this.exec('git fetch origin');
+        this.exec('git fetch -p');
+        this.exec(`git checkout ${baseBranch}`);
+        this.exec('git pull');
+        this.exec(`git checkout -b ${targetBranch}`);
+
+        const shas = dependabotPRs.map((d) => d.head.sha);
+        for (const sha of shas) {
+          this.exec(`git cherry-pick ${sha} --strategy-option=theirs`);
+        }
+
+        if (!this.flags['no-pr']) {
+          this.exec(`git push -u origin ${targetBranch} --no-verify`);
+          const response = await octokit.request('POST /repos/{owner}/{repo}/pulls', {
+            owner,
+            repo,
+            head: targetBranch,
+            base: baseBranch,
+            body: prBody,
+            title: prTitle,
+          });
+
+          this.log();
+          // eslint-disable-next-line no-underscore-dangle
+          this.log(`${green('Created Pull Request:')} ${response.data._links.html.href}`);
+        }
+      } catch (err) {
+        this.error(err);
+      }
+    }
+  }
+
+  private async getOwnerAndRepo(): Promise<{ owner: string; repo: string }> {
+    const pkgJson = (await fs.readJson('package.json')) as PackageJson;
+    if (pkgJson.repository && isString(pkgJson.repository)) {
+      const [owner, repo] = pkgJson.repository?.split('/');
+      return { owner, repo };
+    } else {
+      return {
+        owner: ensureString(this.flags.owner, 'You must specify an owner'),
+        repo: ensureString(this.flags.repo, 'You must specify a respository'),
+      };
+    }
+  }
+
+  private meetsVersionCriteria(title: string): boolean {
+    const versionsRegex = /[0-9]+.[0-9]+.[0-9]+/g;
+    const [from, to] = title.match(versionsRegex);
+
+    const bumpType = diff(from, to) as BumpType;
+    const inclusionMap = {
+      major: ['major', 'minor', 'patch'] as BumpType[],
+      minor: ['minor', 'patch'] as BumpType[],
+      patch: ['patch'] as BumpType[],
+    };
+
+    const maxVersionBump = this.flags['max-version-bump'] as BumpType;
+    const includeBumps = inclusionMap[maxVersionBump];
+    return includeBumps.includes(bumpType);
+  }
+
+  private shouldBeIgnored(title: string): boolean {
+    const ignore = this.flags.ignore as string[];
+    return ignore.some((i) => title.includes(i));
+  }
+
+  private exec(cmd: string, silent = false): void {
+    this.log(bold(cmd));
+    exec(cmd, { silent });
+  }
+}

--- a/src/package.ts
+++ b/src/package.ts
@@ -19,6 +19,7 @@ export type PackageJson = {
   scripts: Record<string, string>;
   files?: string[];
   pinnedDependencies?: string[];
+  repository?: string;
 } & AnyJson;
 
 export type ChangedPackageVersions = Array<{

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -24,7 +24,8 @@ describe('SinglePackageRepo', () => {
   let execStub: sinon.SinonStub;
 
   beforeEach(async () => {
-    uxStub = stubInterface<UX>($$.SANDBOX, {}) as unknown as UX;
+    // eslint-disable-next-line prettier/prettier
+    uxStub = (stubInterface<UX>($$.SANDBOX, {}) as unknown) as UX;
   });
 
   describe('isReleasable', () => {
@@ -383,7 +384,8 @@ describe('LernaRepo', () => {
   let revertAllChangesStub: sinon.SinonStub;
 
   beforeEach(async () => {
-    uxStub = stubInterface<UX>($$.SANDBOX, {}) as unknown as UX;
+    // eslint-disable-next-line prettier/prettier
+    uxStub = (stubInterface<UX>($$.SANDBOX, {}) as unknown) as UX;
     // if this stub doesn't exist, the test will revert all of your unstaged changes
     stubMethod($$.SANDBOX, LernaRepo.prototype, 'revertUnstagedChanges').returns(null);
     revertAllChangesStub = stubMethod($$.SANDBOX, LernaRepo.prototype, 'revertAllChanges').returns(null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -556,6 +556,77 @@
   dependencies:
     fancy-test "^1.4.3"
 
+"@octokit/auth-token@^2.4.4":
+  version "2.4.5"
+  resolved "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
+  integrity sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+
+"@octokit/core@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz#b48aa27d755b339fe7550548b340dcc2b513b742"
+  integrity sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.4.12"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.11"
+  resolved "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz#082adc2aebca6dcefa1fb383f5efb3ed081949d1"
+  integrity sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.5.8":
+  version "4.6.2"
+  resolved "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.2.tgz#ec44abdfa87f2b9233282136ae33e4ba446a04e7"
+  integrity sha512-WmsIR1OzOr/3IqfG9JIczI8gMJUMzzyx5j0XXQ4YihHtKlQc+u35VpVoOXhlKAlaBntvry1WpAzPl/a+s3n89Q==
+  dependencies:
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^7.2.3":
+  version "7.3.0"
+  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.0.tgz#1d9ed79828513c57a95e6360b7c9b4749503e79d"
+  integrity sha512-o00X2FCLiEeXZkm1Ab5nvPUdVOlrpediwWZkpizUJ/xtZQsJ4FiQ2RB/dJEmb0Nk+NIz7zyDePcSCu/Y/0M3Ew==
+
+"@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz#72cc91edc870281ad583a42619256b380c600143"
+  integrity sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/@octokit/request/-/request-5.5.0.tgz#6588c532255b8e71886cefa0d2b64b4ad73bf18c"
+  integrity sha512-jxbMLQdQ3heFMZUaTLSCqcKs2oAHEYh7SnLLXyxbZmlULExZ/RXai7QUWWFKowcGGPlCZuKTZg0gSKHWrfYEoQ==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1":
+  version "6.16.2"
+  resolved "https://registry.npmjs.org/@octokit/types/-/types-6.16.2.tgz#62242e0565a3eb99ca2fd376283fe78b4ea057b4"
+  integrity sha512-wWPSynU4oLy3i4KGyk+J1BLwRKyoeW2TwRHgwbDz17WtVFzSK2GOErGliruIx8c+MaYtHSYTx36DSmLNoNbtgA==
+  dependencies:
+    "@octokit/openapi-types" "^7.2.3"
+
 "@salesforce/bunyan@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@salesforce/bunyan/-/bunyan-2.0.0.tgz#8dbe377f2cf7d35348a23260416fee15adba5f97"
@@ -981,6 +1052,11 @@
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
   dependencies:
     "@types/node" "*"
+
+"@types/semver@^7.3.6":
+  version "7.3.6"
+  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz#e9831776f4512a7ba6da53e71c26e5fb67882d63"
+  integrity sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==
 
 "@types/shelljs@^0.8.8":
   version "0.8.8"
@@ -1474,6 +1550,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+before-after-hook@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
+  integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -2529,6 +2610,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+deprecation@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 detect-file@^1.0.0:
   version "1.0.0"
@@ -4365,6 +4451,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-regex@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
@@ -5504,6 +5595,11 @@ nock@^13.0.0:
     json-stringify-safe "^5.0.1"
     lodash.set "^4.3.2"
     propagate "^2.0.0"
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-preload@^0.2.1:
   version "0.2.1"
@@ -6673,7 +6769,7 @@ semver@^7.1.1, semver@^7.3.2:
 
 semver@^7.2.1, semver@^7.3.5:
   version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
@@ -7621,6 +7717,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
### What does this PR do?

Adds `dependabot:consolidate`

I **do not** think we should incorporate this command into our monthly checklist. I would prefer to start auto-merging minor/patch dependabot PRs. However, this is still a nice tool to have around 

### Help

```
~/code/plugin-release-management [mdonnalley/dependabot-consolidate] : bin/run dependabot:consolidate --help
consolidate dependabot PRs into a single PR

USAGE
  $ sfdx dependabot:consolidate -m major|minor|patch -b <string> -t <string> [--ignore <array>] [-d] [--no-pr] [-o <string>] [-r <string>] [--json] [--loglevel
  trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]

OPTIONS
  -b, --base-branch=base-branch                                                     (required) [default: main] name of the base branch for merging
  -d, --dryrun                                                                      only show what would happen if you consolidated dependabot PRs
  -m, --max-version-bump=(major|minor|patch)                                        (required) [default: minor] the maximum version bump you want to be included

  -o, --owner=owner                                                                 the organization that the repository belongs to. This defaults to the owner specified
                                                                                    in the package.json

  -r, --repo=repo                                                                   the repository you want to consolidate PRs on. This defaults to the repository
                                                                                    specified in the package.json

  -t, --target-branch=target-branch                                                 (required) [default: consolidate-dependabot] name of the target branch for merging

  --ignore=ignore                                                                   [default: ] ignore any PRs with titles that include this value

  --json                                                                            format output as json

  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for this command invocation

  --no-pr                                                                           do everything but create the PR

EXAMPLES
  sfdx dependabot:consolidate --max-version-bump patch
  sfdx dependabot:consolidate --max-version-bump minor
  sfdx dependabot:consolidate --max-version-bump major
```

### What issues does this PR fix or reference?
[skip-validate-pr]