### PR TITLE
feat: add npm:package:promote command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -46,6 +46,11 @@
     "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign"]
   },
   {
+    "command": "npm:package:promote",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["candidate", "dryrun", "json", "loglevel", "target"]
+  },
+  {
     "command": "npm:package:release",
     "plugin": "@salesforce/plugin-release-management",
     "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign"]

--- a/messages/npm.package.promote.json
+++ b/messages/npm.package.promote.json
@@ -1,0 +1,10 @@
+{
+  "description": "promote an npm package",
+  "examples": ["<%= config.bin %> <%= command.id %> --candidate latest-rc --target latest"],
+  "dryrun": "If true, only show what would happen",
+  "candidate": "the npm tag that you want to promote",
+  "target": "the npm tag that you are promoting to",
+  "InvalidRepoType": "Cannot run this command on a monorepo.",
+  "InvalidToken": "This command requries an npm publish token.",
+  "InvalidTag": "the %s tag does not exist in npm."
+}

--- a/src/commands/npm/package/promote.ts
+++ b/src/commands/npm/package/promote.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as os from 'os';
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { Messages, SfdxError } from '@salesforce/core';
+import { Env } from '@salesforce/kit';
+import { ensureString } from '@salesforce/ts-types';
+import { exec } from 'shelljs';
+import { bold } from 'chalk';
+import { isMonoRepo } from '../../../repository';
+import { Package } from '../../../package';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'npm.package.promote');
+
+interface Token {
+  token: string;
+  key: string;
+  readonly: boolean;
+  automation: boolean;
+}
+
+export default class Promote extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly flagsConfig: FlagsConfig = {
+    dryrun: flags.boolean({
+      char: 'd',
+      default: false,
+      description: messages.getMessage('dryrun'),
+    }),
+    target: flags.string({
+      char: 't',
+      default: 'latest',
+      description: messages.getMessage('target'),
+    }),
+    candidate: flags.string({
+      char: 'c',
+      description: messages.getMessage('candidate'),
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    if (await isMonoRepo()) {
+      const errType = 'InvalidRepoType';
+      throw new SfdxError(messages.getMessage(errType), errType);
+    }
+
+    const token = ensureString(new Env().getString('NPM_TOKEN'), 'NPM_TOKEN must be set in the environment');
+    const tokens = JSON.parse(exec('npm token list --json', { silent: true }).stdout) as Token[];
+    const publishTokens = tokens.filter((t) => t.readonly === false && t.automation === false);
+    const match = publishTokens.find((t) => token.substring(0, 6) === t.token);
+
+    if (!match) {
+      const errType = 'InvalidToken';
+      throw new SfdxError(messages.getMessage(errType), errType);
+    }
+    const pkg = await Package.create();
+    const tags = pkg.npmPackage['dist-tags'];
+    const candidate = ensureString(this.flags.candidate);
+    const target = ensureString(this.flags.target);
+
+    if (!tags[candidate]) {
+      const errType = 'InvalidTag';
+      throw new SfdxError(messages.getMessage(errType, [candidate]), errType);
+    }
+
+    this.log(`Promoting ${pkg.name}@${tags[candidate]} from ${bold(candidate)} to ${bold(target)}`);
+    if (target) {
+      this.warn(`This will overwrite the existing ${target} version: ${tags[target]}`);
+      this.log();
+    }
+
+    if (!this.flags.dryrun) {
+      exec(`npm dist-tag add ${pkg.name}@${tags[candidate]} ${target} --json`);
+    }
+  }
+}

--- a/src/package.ts
+++ b/src/package.ts
@@ -32,7 +32,7 @@ export type NpmPackage = {
   name: string;
   version: string;
   versions: string[];
-  'dist-tags': string[];
+  'dist-tags': Record<string, string>;
 } & AnyJson;
 
 export interface VersionValidation {
@@ -172,7 +172,7 @@ export class Package extends AsyncOptionalCreatable {
       name: this.name,
       version: this.packageJson.version,
       versions: [],
-      'dist-tags': [],
+      'dist-tags': {},
     };
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds an `npm:package:promote` command for promoting canary releases to latest. This is a requirement for plugin-functions,  which needs to have a canary release. Their flow will look something like this:

* merge all PRs into a canary branch
* a merge into the canary branch will trigger a new release under their canary tag
* once they're ready, they will merge the canary branch into the `main` branch
* the merge into `main` will promote the canary release to `latest` (instead of publishing a new version)

This command essentially wraps around the [npm dist-tag add](https://docs.npmjs.com/cli/v7/commands/npm-dist-tag) command but it adds a few helpful features:
* verifies that the `NPM_TOKEN` is a publishing token since automation tokens don't have the ability to manipulate tags
* ensures that the `candidate` tag exists
* adds a `dryrun` option

This will be used by the orb: https://github.com/forcedotcom/npm-release-management-orb/pull/62

### Usage

#### CLI
```
~/code/plugin-release-management [mdonnalley/promote] : bin/run npm:package:promote --help
promote an npm package

USAGE
  $ sfdx npm:package:promote -c <string> [-d] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]

OPTIONS
  -c, --candidate=candidate                                                         (required) the npm tag that you want to promote
  -d, --dryrun                                                                      If true, only show what would happen
  -t, --target=target                                                               [default: latest] the npm tag that you are promoting to
  --json                                                                            format output as json
  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for this command invocation

EXAMPLE
  sfdx npm:package:promote --candidate latest-rc --target latest
```

#### CircleCI

```yaml
# publish canary tag on merge into canary branch
- release-management/release-package:
    sign: true
    github-release: true
    tag: canary
    requires:
      - release-management/test-package
    filters:
      branches:
        only: canary
# promote to latest on merge into main
- release-management/promote-package:
    target: latest
    candidate: canary
    requires:
      - release-management/test-package
    filters:
      branches:
        only: main
```

### What issues does this PR fix or reference?
@W-9457190@