### PR TITLE
fix: forgot to load the messageDir

### DIFF
--- a/src/commands/dependabot/automerge.ts
+++ b/src/commands/dependabot/automerge.ts
@@ -13,6 +13,7 @@ import { ensureString } from '@salesforce/ts-types';
 import { Messages } from '@salesforce/core';
 import { meetsVersionCriteria, maxVersionBumpFlag, getOwnerAndRepo } from '../../dependabot';
 
+Messages.importMessagesDirectory(__dirname);
 const messagesFromConsolidate = Messages.loadMessages(
   '@salesforce/plugin-release-management',
   'dependabot.consolidate'


### PR DESCRIPTION
What does this PR do? [repeat attempt]
merges one green, up-to-date-with-main dependabot PR of the specified maximum version bump
the intended use of this command is to run nightly on a repo from the orb

What issues does this PR fix or reference?
@W-9457889@