### PR TITLE
Sm/fix dependabot message

### DIFF
--- a/src/commands/dependabot/automerge.ts
+++ b/src/commands/dependabot/automerge.ts
@@ -14,11 +14,11 @@ import { Messages } from '@salesforce/core';
 import { meetsVersionCriteria, maxVersionBumpFlag, getOwnerAndRepo } from '../../dependabot';
 
 Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'dependabot.automerge');
 const messagesFromConsolidate = Messages.loadMessages(
   '@salesforce/plugin-release-management',
   'dependabot.consolidate'
 );
-const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'dependabot.automerge');
 
 interface PullRequest {
   state: string;

--- a/src/commands/dependabot/automerge.ts
+++ b/src/commands/dependabot/automerge.ts
@@ -14,6 +14,7 @@ import { Messages } from '@salesforce/core';
 import { meetsVersionCriteria, maxVersionBumpFlag, getOwnerAndRepo } from '../../dependabot';
 
 Messages.importMessagesDirectory(__dirname);
+
 const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'dependabot.automerge');
 const messagesFromConsolidate = Messages.loadMessages(
   '@salesforce/plugin-release-management',

--- a/src/dependabot.ts
+++ b/src/dependabot.ts
@@ -12,6 +12,7 @@ import { PackageJson } from './package';
 
 type BumpType = Extract<ReleaseType, 'major' | 'minor' | 'patch'>;
 
+Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'dependabot.consolidate');
 
 export const meetsVersionCriteria = (title: string, maxVersionBump: BumpType): boolean => {


### PR DESCRIPTION
### What does this PR do?
previous PR broke the new dependabot commands by forgetting to import the messages directory in the shared dependabot flag (I think).  

Side note: there's no good way to catch this at dev/compile/test time (it works fine via plugin:link) and only fails at runtime.

### What issues does this PR fix or reference?
still trying to get @W-9477765@ to work some night