### PR TITLE
fix: add verify flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -43,7 +43,7 @@
   {
     "command": "npm:lerna:release",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign"]
+    "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign", "verify"]
   },
   {
     "command": "npm:package:promote",
@@ -53,7 +53,7 @@
   {
     "command": "npm:package:release",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign"]
+    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign", "verify"]
   },
   {
     "command": "npm:release:validate",

--- a/messages/npm.lerna.release.json
+++ b/messages/npm.lerna.release.json
@@ -6,6 +6,7 @@
   "npmAccess": "access level to use when publishing to npm",
   "install": "run yarn install and build on repository",
   "githubRelease": "create release in github based on the package changes",
+  "verify": "verify npm registry has new version after publish and digital signature",
   "InvalidNextVersion": "%s already exists in the public npm registry",
   "MissingDependencies": "Missing requred environment variables or utilites",
   "InvalidRepoType": "Cannot run this command on a non-monorepo. Use sfdx npm:package:release instead.",

--- a/messages/npm.package.release.json
+++ b/messages/npm.package.release.json
@@ -6,6 +6,7 @@
   "npmAccess": "access level to use when publishing to npm",
   "install": "run yarn install and build on repository",
   "prerelease": "determine the next version as <version>-<prerelease>.0 if version is not manually set",
+  "verify": "verify npm registry has new version after publish and digital signature",
   "InvalidNextVersion": "%s already exists in the public npm registry",
   "MissingDependencies": "Missing requred environment variables or utilites",
   "InvalidRepoType": "Cannot run this command on a monorepo. Use sfdx npm:monorepo:release instead."

--- a/src/commands/npm/lerna/release.ts
+++ b/src/commands/npm/lerna/release.ts
@@ -52,6 +52,11 @@ export default class Release extends SfdxCommand {
       default: false,
       description: messages.getMessage('githubRelease'),
     }),
+    verify: flags.boolean({
+      description: messages.getMessage('verify'),
+      default: true,
+      allowNo: true,
+    }),
   };
 
   public async run(): Promise<ReleaseResult[]> {
@@ -126,7 +131,7 @@ export default class Release extends SfdxCommand {
       dryrun: this.flags.dryrun as boolean,
     });
 
-    if (!this.flags.dryrun) {
+    if (!this.flags.dryrun && this.flags.verify) {
       lernaRepo.printStage('Waiting For Availablity');
       const found = await lernaRepo.waitForAvailability();
       if (!found) {
@@ -134,7 +139,7 @@ export default class Release extends SfdxCommand {
       }
     }
 
-    if (this.flags.sign && !this.flags.dryrun) {
+    if (this.flags.sign && this.flags.verify && !this.flags.dryrun) {
       lernaRepo.printStage('Verify Signed Packaged');
       lernaRepo.verifySignature(this.flags.sign);
     }

--- a/src/commands/npm/package/release.ts
+++ b/src/commands/npm/package/release.ts
@@ -50,6 +50,11 @@ export default class Release extends SfdxCommand {
     prerelease: flags.string({
       description: messages.getMessage('prerelease'),
     }),
+    verify: flags.boolean({
+      description: messages.getMessage('verify'),
+      default: true,
+      allowNo: true,
+    }),
   };
 
   public async run(): Promise<ReleaseResult> {
@@ -115,7 +120,7 @@ export default class Release extends SfdxCommand {
       dryrun: this.flags.dryrun as boolean,
     });
 
-    if (!this.flags.dryrun) {
+    if (!this.flags.dryrun && this.flags.verify) {
       pkg.printStage('Waiting For Availability');
       const found = await pkg.waitForAvailability();
       if (!found) {
@@ -123,7 +128,7 @@ export default class Release extends SfdxCommand {
       }
     }
 
-    if (this.flags.sign && !this.flags.dryrun) {
+    if (this.flags.sign && this.flags.verify && !this.flags.dryrun) {
       pkg.printStage('Verify Signed Packaged');
       pkg.verifySignature();
     }


### PR DESCRIPTION
### What does this PR do?
Adds a verify flag to lerna and package release cmds with allowNo.
Defaults to true and when --no-verify will skip post publish availability check and digital signature verifications
### What issues does this PR fix or reference?
@W-8750717@