### PR TITLE
Adds commands to support sf release build

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,88 +1,192 @@
 [
-  {
-    "command": "circleci",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["contains-package-type", "json", "loglevel"]
-  },
-  {
-    "command": "circleci:envvar:update",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
-  },
-  {
-    "command": "cli:tarballs:verify",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["cli", "json", "loglevel"]
-  },
-  {
-    "command": "cli:versions:inspect",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["channels", "dependencies", "json", "locations", "loglevel", "salesforce"]
-  },
-  {
-    "command": "dependabot:automerge",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "owner", "repo"]
-  },
-  {
-    "command": "dependabot:consolidate",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": [
-      "base-branch",
-      "dryrun",
-      "ignore",
-      "json",
-      "loglevel",
-      "max-version-bump",
-      "no-pr",
-      "owner",
-      "repo",
-      "target-branch"
-    ]
-  },
-  {
-    "command": "npm:dependencies:pin",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "tag"]
-  },
-  {
-    "command": "npm:lerna:release",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign", "verify"]
-  },
-  {
-    "command": "npm:package:promote",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["candidate", "dryrun", "json", "loglevel", "target"]
-  },
-  {
-    "command": "npm:package:release",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign", "verify"]
-  },
-  {
-    "command": "npm:release:validate",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "verbose"]
-  },
-  {
-    "command": "repositories",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"]
-  },
-  {
-    "command": "trust:sign",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "privatekeypath", "publickeyurl", "signatureurl", "target", "tarpath"]
-  },
-  {
-    "command": "trust:upload",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["bucket", "json", "keyprefix", "loglevel", "signature"]
-  },
-  {
-    "command": "typescript:update",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "target", "version"]
-  }
+    {
+        "command": "circleci",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "contains-package-type",
+            "json",
+            "loglevel"
+        ]
+    },
+    {
+        "command": "circleci:envvar:update",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "envvar",
+            "json",
+            "loglevel",
+            "slug"
+        ]
+    },
+    {
+        "command": "cli:tarballs:prepare",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "types",
+            "verbose"
+        ]
+    },
+    {
+        "command": "cli:tarballs:verify",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "cli",
+            "json",
+            "loglevel"
+        ]
+    },
+    {
+        "command": "cli:versions:inspect",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "channels",
+            "dependencies",
+            "json",
+            "locations",
+            "loglevel",
+            "salesforce"
+        ]
+    },
+    {
+        "command": "dependabot:automerge",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "max-version-bump",
+            "owner",
+            "repo"
+        ]
+    },
+    {
+        "command": "dependabot:consolidate",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "base-branch",
+            "dryrun",
+            "ignore",
+            "json",
+            "loglevel",
+            "max-version-bump",
+            "no-pr",
+            "owner",
+            "repo",
+            "target-branch"
+        ]
+    },
+    {
+        "command": "npm:dependencies:pin",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "tag"
+        ]
+    },
+    {
+        "command": "npm:lerna:release",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "githubrelease",
+            "install",
+            "json",
+            "loglevel",
+            "npmaccess",
+            "npmtag",
+            "sign",
+            "verify"
+        ]
+    },
+    {
+        "command": "npm:package:promote",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "candidate",
+            "dryrun",
+            "json",
+            "loglevel",
+            "target"
+        ]
+    },
+    {
+        "command": "npm:package:release",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "install",
+            "json",
+            "loglevel",
+            "npmaccess",
+            "npmtag",
+            "prerelease",
+            "sign",
+            "verify"
+        ]
+    },
+    {
+        "command": "npm:release:validate",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "verbose"
+        ]
+    },
+    {
+        "command": "repositories",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "columns",
+            "csv",
+            "extended",
+            "filter",
+            "json",
+            "loglevel",
+            "no-header",
+            "no-truncate",
+            "output",
+            "sort"
+        ]
+    },
+    {
+        "command": "trust:sign",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "privatekeypath",
+            "publickeyurl",
+            "signatureurl",
+            "target",
+            "tarpath"
+        ]
+    },
+    {
+        "command": "trust:upload",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "bucket",
+            "json",
+            "keyprefix",
+            "loglevel",
+            "signature"
+        ]
+    },
+    {
+        "command": "typescript:update",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "target",
+            "version"
+        ]
+    }
 ]

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -10,6 +10,11 @@
     "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
   },
   {
+    "command": "cli:tarballs:verify",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["cli", "json", "loglevel"]
+  },
+  {
     "command": "cli:versions:inspect",
     "plugin": "@salesforce/plugin-release-management",
     "flags": ["channels", "dependencies", "json", "locations", "loglevel", "salesforce"]

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,192 +1,93 @@
 [
-    {
-        "command": "circleci",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "contains-package-type",
-            "json",
-            "loglevel"
-        ]
-    },
-    {
-        "command": "circleci:envvar:update",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "envvar",
-            "json",
-            "loglevel",
-            "slug"
-        ]
-    },
-    {
-        "command": "cli:tarballs:prepare",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "json",
-            "loglevel",
-            "types",
-            "verbose"
-        ]
-    },
-    {
-        "command": "cli:tarballs:verify",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "cli",
-            "json",
-            "loglevel"
-        ]
-    },
-    {
-        "command": "cli:versions:inspect",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "channels",
-            "dependencies",
-            "json",
-            "locations",
-            "loglevel",
-            "salesforce"
-        ]
-    },
-    {
-        "command": "dependabot:automerge",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "json",
-            "loglevel",
-            "max-version-bump",
-            "owner",
-            "repo"
-        ]
-    },
-    {
-        "command": "dependabot:consolidate",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "base-branch",
-            "dryrun",
-            "ignore",
-            "json",
-            "loglevel",
-            "max-version-bump",
-            "no-pr",
-            "owner",
-            "repo",
-            "target-branch"
-        ]
-    },
-    {
-        "command": "npm:dependencies:pin",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "json",
-            "loglevel",
-            "tag"
-        ]
-    },
-    {
-        "command": "npm:lerna:release",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "githubrelease",
-            "install",
-            "json",
-            "loglevel",
-            "npmaccess",
-            "npmtag",
-            "sign",
-            "verify"
-        ]
-    },
-    {
-        "command": "npm:package:promote",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "candidate",
-            "dryrun",
-            "json",
-            "loglevel",
-            "target"
-        ]
-    },
-    {
-        "command": "npm:package:release",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "install",
-            "json",
-            "loglevel",
-            "npmaccess",
-            "npmtag",
-            "prerelease",
-            "sign",
-            "verify"
-        ]
-    },
-    {
-        "command": "npm:release:validate",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "json",
-            "loglevel",
-            "verbose"
-        ]
-    },
-    {
-        "command": "repositories",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "columns",
-            "csv",
-            "extended",
-            "filter",
-            "json",
-            "loglevel",
-            "no-header",
-            "no-truncate",
-            "output",
-            "sort"
-        ]
-    },
-    {
-        "command": "trust:sign",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "json",
-            "loglevel",
-            "privatekeypath",
-            "publickeyurl",
-            "signatureurl",
-            "target",
-            "tarpath"
-        ]
-    },
-    {
-        "command": "trust:upload",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "bucket",
-            "json",
-            "keyprefix",
-            "loglevel",
-            "signature"
-        ]
-    },
-    {
-        "command": "typescript:update",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "json",
-            "loglevel",
-            "target",
-            "version"
-        ]
-    }
+  {
+    "command": "circleci",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["contains-package-type", "json", "loglevel"]
+  },
+  {
+    "command": "circleci:envvar:update",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
+  },
+  {
+    "command": "cli:tarballs:prepare",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "json", "loglevel", "types", "verbose"]
+  },
+  {
+    "command": "cli:tarballs:verify",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["cli", "json", "loglevel"]
+  },
+  {
+    "command": "cli:versions:inspect",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["channels", "cli", "dependencies", "json", "locations", "loglevel", "salesforce"]
+  },
+  {
+    "command": "dependabot:automerge",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "owner", "repo"]
+  },
+  {
+    "command": "dependabot:consolidate",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": [
+      "base-branch",
+      "dryrun",
+      "ignore",
+      "json",
+      "loglevel",
+      "max-version-bump",
+      "no-pr",
+      "owner",
+      "repo",
+      "target-branch"
+    ]
+  },
+  {
+    "command": "npm:dependencies:pin",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "json", "loglevel", "tag"]
+  },
+  {
+    "command": "npm:lerna:release",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign", "verify"]
+  },
+  {
+    "command": "npm:package:promote",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["candidate", "dryrun", "json", "loglevel", "target"]
+  },
+  {
+    "command": "npm:package:release",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign", "verify"]
+  },
+  {
+    "command": "npm:release:validate",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel", "verbose"]
+  },
+  {
+    "command": "repositories",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"]
+  },
+  {
+    "command": "trust:sign",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel", "privatekeypath", "publickeyurl", "signatureurl", "target", "tarpath"]
+  },
+  {
+    "command": "trust:upload",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["bucket", "json", "keyprefix", "loglevel", "signature"]
+  },
+  {
+    "command": "typescript:update",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel", "target", "version"]
+  }
 ]

--- a/messages/cli.tarballs.prepare.json
+++ b/messages/cli.tarballs.prepare.json
@@ -1,0 +1,7 @@
+{
+  "description": "remove unnecessary files from node_modules",
+  "dryrun": "only show what would be removed from node_modules",
+  "verbose": "show all files paths being removed",
+  "types": "remove all types (.d.ts) files from node_modules ",
+  "examples": ["<%= config.bin %> <%= command.id %>"]
+}

--- a/messages/cli.tarballs.verify.json
+++ b/messages/cli.tarballs.verify.json
@@ -1,0 +1,9 @@
+{
+  "description": "verify that tarballs are ready to be uploaded",
+  "cli": "the cli to verify",
+  "examples": [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --cli sfdx",
+    "<%= config.bin %> <%= command.id %> --cli sf"
+  ]
+}

--- a/messages/cli.versions.inspect.json
+++ b/messages/cli.versions.inspect.json
@@ -4,6 +4,7 @@
   "salesforce": "show versions of salesforce owned dependencies",
   "channels": "the channel you want to inspect (for achives, latest and latest-rc are translated to stable and stable-rc. And vice-versa for npm)",
   "locations": "the location you want to inspect",
+  "cli": "the CLI you want to inspect",
   "examples": [
     "<%= config.bin %> <%= command.id %> -l archive -c stable",
     "<%= config.bin %> <%= command.id %> -l archive -c stable-rc",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,9 @@
         "subtopics": {
           "versions": {
             "description": "view CLI versions"
+          },
+          "tarballs": {
+            "description": "CLI tarballs"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -110,10 +110,10 @@
         "description": "get information on the cli",
         "subtopics": {
           "versions": {
-            "description": "view CLI versions"
+            "description": "interact with CLI versions"
           },
           "tarballs": {
-            "description": "CLI tarballs"
+            "description": "interact with CLI tarballs"
           }
         }
       },

--- a/src/commands/cli/tarballs/prepare.ts
+++ b/src/commands/cli/tarballs/prepare.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as os from 'os';
+import * as fg from 'fast-glob';
+import { pwd, rm } from 'shelljs';
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { Messages } from '@salesforce/core';
+import { red } from 'chalk';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'cli.tarballs.prepare');
+
+/**
+ * The functionality of this command is taken entirely from https://github.com/salesforcecli/sfdx-cli/blob/v7.109.0/scripts/clean-for-tarballs
+ */
+export default class Verify extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly flagsConfig: FlagsConfig = {
+    dryrun: flags.boolean({
+      description: messages.getMessage('dryrun'),
+      default: false,
+      char: 'd',
+    }),
+    types: flags.boolean({
+      description: messages.getMessage('types'),
+      default: false,
+      char: 't',
+    }),
+    verbose: flags.builtin({
+      description: messages.getMessage('verbose'),
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const workingDir = pwd().stdout;
+    const baseDirGlob = `${workingDir}/node_modules`;
+
+    // Remove JSforceTestSuite from dist
+    const jsForceTestSuite = await this.find(`${baseDirGlob}/JSforceTestSuite`, { onlyDirectories: true });
+    this.remove(jsForceTestSuite, 'JSforceTestSuite files');
+
+    // Module readmes and other markdown docs not found in template directories
+    const markdownFiles = await this.find(`${baseDirGlob}/**/*.md`, { excludeDirectory: 'templates' });
+    this.remove(markdownFiles, '.md files');
+
+    // Module .gitignore not found in template directories
+    const gitignore = await this.find(`${baseDirGlob}/**/.gitignore`, { excludeDirectory: 'templates' });
+    this.remove(gitignore, '.gitignore files');
+
+    // Module .gitattributes not found in template directories
+    const gitattributes = await this.find(`${baseDirGlob}/**/.gitattributes`, { excludeDirectory: 'templates' });
+    this.remove(gitattributes, '.gitattributes files');
+
+    // Module .eslintrc not found in template directories
+    const eslintrc = await this.find(`${baseDirGlob}/**/.eslintrc`, { excludeDirectory: 'templates' });
+    this.remove(eslintrc, '.eslintrc files');
+
+    // Module appveyor.yml not found in template directories
+    const appveyor = await this.find(`${baseDirGlob}/**/appveyor.yml`, { excludeDirectory: 'templates' });
+    this.remove(appveyor, 'appveyor.yml files');
+
+    // Module circle.yml not found in template directories
+    const circle = await this.find(`${baseDirGlob}/**/circle.yml`, { excludeDirectory: 'templates' });
+    this.remove(circle, 'circle.yml files');
+
+    // Module test dirs, except in salesforce-alm, which includes production source code in such a dir
+    const allowedTestDirs = [
+      'command',
+      'commands',
+      'lib',
+      'dist',
+      'salesforce-alm',
+      '@salesforce/plugin-templates',
+      '@salesforce/plugin-generator',
+    ];
+    const testDirs = (await this.find(`${baseDirGlob}/**/test`, { onlyDirectories: true })).filter((f) => {
+      return !allowedTestDirs.some((d) => f.includes(d));
+    });
+    this.remove(testDirs, 'test directories');
+
+    // JS map files, except the ill-named `lodash.map` (it's a directory and we'll also filter out matches if found for good measure)
+    const maps = (await this.find(`${baseDirGlob}/**/*.map`)).filter((f) => !f.includes('lodash.map'));
+    this.remove(maps, '*.map files');
+
+    // In case yarn autoclean is disabled, delete some known windows file path length offenders
+    const nycOutput = await this.find(`${baseDirGlob}/**/.nyc_output`);
+    this.remove(nycOutput, '.nyc_output files');
+
+    // Large files shipped with jsforce
+    const jsforceBuild = await this.find(`${baseDirGlob}/jsforce/build`, { onlyDirectories: true });
+    this.remove(jsforceBuild, 'jsforce/build directory');
+
+    // This breaks compilation. We need to probably do this right before the pack, but then this will
+    // break compilation the next time compile is ran without doing a yarn install --force
+    // We don't need types in the production code
+    if (this.flags.types) {
+      const types = await this.find(`${baseDirGlob}/**/*.d.ts`);
+      this.remove(types, '*.d.ts files');
+    }
+  }
+
+  private async find(globPattern: string, options: fg.Options & { excludeDirectory?: string } = {}): Promise<string[]> {
+    const patterns = [globPattern];
+    if (options.excludeDirectory) {
+      const parts = globPattern.split('/');
+      const lastPart = parts.pop();
+      parts.push(options.excludeDirectory, '**', lastPart);
+      const exclusionPattern = `!${parts.join('/')}`;
+      patterns.push(exclusionPattern);
+    }
+    if (options?.excludeDirectory) delete options.excludeDirectory;
+    return fg(patterns, options);
+  }
+
+  private remove(files: string[], type: string): void {
+    if (!files.length) return;
+    const msg = this.flags.dryrun
+      ? `${red.bold('[DRYRUN] Removing:')} ${files.length} ${type}`
+      : `${red.bold('Removing:')} ${files.length} ${type}`;
+    this.log(msg);
+
+    if (this.flags.verbose) {
+      files.forEach((f) => this.log(`  ${f}`));
+    }
+
+    if (!this.flags.dryrun) {
+      files.forEach((f) => rm('-rf', f));
+    }
+  }
+}

--- a/src/commands/cli/tarballs/verify.ts
+++ b/src/commands/cli/tarballs/verify.ts
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fg from 'fast-glob';
+import { exec } from 'shelljs';
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { fs, Messages, SfdxError } from '@salesforce/core';
+import { ensure } from '@salesforce/ts-types';
+import { red, yellow, green } from 'chalk';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'cli.tarballs.verify');
+
+export enum CLI {
+  SF = 'sf',
+  SFDX = 'sfdx',
+}
+
+const PASSED = green.bold('PASSED');
+const FAILED = red.bold('FAILED');
+
+/**
+ * The functionality of this command is taken entirely from https://github.com/salesforcecli/sfdx-cli/blob/v7.109.0/scripts/verify-tarballs
+ */
+export default class Verify extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly flagsConfig: FlagsConfig = {
+    cli: flags.enum({
+      description: messages.getMessage('cli'),
+      options: Object.values(CLI),
+      default: 'sfdx',
+      char: 'c',
+    }),
+  };
+
+  private baseDir!: string;
+  private step = 1;
+  private totalSteps = 1;
+
+  public async run(): Promise<void> {
+    const cli = ensure<CLI>(this.flags.cli);
+    this.baseDir = path.join('tmp', cli);
+    const cliRunLists: Record<CLI, Array<() => Promise<void>>> = {
+      [CLI.SFDX]: [
+        this.ensureNoWebDriverIO.bind(this),
+        this.ensureNoHerokuCliUtilNyc.bind(this),
+        this.ensureWindowsPathLengths.bind(this),
+        this.ensureApexNode.bind(this),
+        this.ensurePluginGenerateTestTemplates.bind(this),
+        this.ensureTemplatesCommands.bind(this),
+        this.ensureNoDistTestsOrMaps.bind(this),
+        this.ensureNoUnexpectedfiles.bind(this),
+        // TODO: add this once https://github.com/salesforcecli/sfdx-cli/pull/195 is merged
+        // this.ensureSfIsIncluded.bind(this),
+      ],
+      [CLI.SF]: [
+        this.ensureWindowsPathLengths.bind(this),
+        this.ensureNoDistTestsOrMaps.bind(this),
+        this.ensureNoUnexpectedfiles.bind(this),
+      ],
+    };
+
+    this.totalSteps = cliRunLists[cli].length;
+    for (const test of cliRunLists[cli]) {
+      await test();
+    }
+  }
+
+  private async execute(msg: string, validate: () => Promise<boolean>): Promise<boolean> {
+    this.ux.cli.action.start(`[${this.step}/${this.totalSteps}] ${msg}`);
+    if (!(await validate())) {
+      this.ux.cli.action.stop(FAILED);
+      return false;
+    }
+    this.step += 1;
+    this.ux.cli.action.stop(PASSED);
+    return true;
+  }
+
+  private async ensureNoWebDriverIO(): Promise<void> {
+    const webDriverIo = path.join(this.baseDir, 'node_modules', 'webdriverio', 'test');
+    const validate = async (): Promise<boolean> => {
+      return !(await fs.fileExists(webDriverIo));
+    };
+    const passed = await this.execute('Ensure webdriverio does not exist', validate);
+    if (!passed) {
+      throw new SfdxError(`${webDriverIo} is present. Was the clean not aggressive enough?`);
+    }
+  }
+
+  private async ensureNoHerokuCliUtilNyc(): Promise<void> {
+    const herokuCliUtil = path.join(
+      this.baseDir,
+      'node_modules',
+      '@salesforce',
+      'plugin-templates',
+      'node_modules',
+      'salesforce-alm',
+      'node_modules',
+      'heroku-cli-util',
+      '.nyc_output'
+    );
+    const validate = async (): Promise<boolean> => {
+      return !(await fs.fileExists(herokuCliUtil));
+    };
+    const passed = await this.execute('Ensure heroku-cli-util/.nyc_output does not exist', validate);
+    if (!passed) {
+      throw new SfdxError(`${herokuCliUtil} is present. Was the clean not aggressive enough?`);
+    }
+  }
+
+  /**
+   * Make sure cleaning was not too aggressive and that path lengths in the build tree are as windows-safe as they can be
+   *
+   * Check for potentially overflowing windows paths:
+   * - assume a max practical windows username length of 64 characters (https://technet.microsoft.com/it-it/library/bb726984(en-us).aspx)
+   * - add characters to account for the root sfdx client tmp untar path for a total of 135
+   * e.g. C:\Users\<username>\AppData\Local\sfdx\tmp\sfdx-cli-v7.xx.yy-abcdef-windows-x64\
+   * - subtract those 135 characters from the max windows path length of 259 to yield the allowable length of 124 path characters
+   * - considering that we currently have some dependencies in the built output that exceed 124 characters (up to 139 in salesforce-lightning-cli)
+   * we will consider the maximum path length of 139, plus 5 as a buffer, as the hard upper limit to our allowable path length;
+   * this leaves us a relatively comfortable maximum windows username length of 48 characters with a hard maximum path length of 144 characters
+   * - then scan the cleaned build output directory for paths exceding this threshold, and exit with an error if detected
+   */
+  private async ensureWindowsPathLengths(): Promise<void> {
+    const validate = async (): Promise<boolean> => {
+      const warningLength = 124;
+      const maxLength = 146;
+      const paths = (await fg(`${this.baseDir}/node_modules/**/*`)).map((p) =>
+        p.replace(`${this.baseDir}${path.sep}`, '')
+      );
+      const warnPaths = paths.filter((p) => p.length >= warningLength && p.length < maxLength).sort();
+      const errorPaths = paths.filter((p) => p.length >= maxLength).sort();
+      if (warnPaths.length) {
+        this.log(
+          `${yellow.bold(
+            'WARNING:'
+          )} Some paths could result in update errors for Windows users with usernames greater than 48 characters!`
+        );
+        warnPaths.forEach((p) => this.log(`${p.length} - ${p}`));
+      }
+      if (errorPaths.length) {
+        this.log(`${red.bold('ERROR:')} Unacceptably long paths detected in base build!`);
+        errorPaths.forEach((p) => this.log(`${p.length} - ${p}`));
+        return false;
+      }
+
+      return true;
+    };
+    const passed = await this.execute('Ensure windows path lengths', validate);
+    if (!passed) {
+      throw new SfdxError('Unacceptably long paths detected in base build!');
+    }
+  }
+
+  private async ensureApexNode(): Promise<void> {
+    const apexNodePath = path.join(this.baseDir, 'node_modules', '@salesforce', 'apex-node', 'lib', 'src', 'tests');
+    const validate = async (): Promise<boolean> => fs.fileExists(apexNodePath);
+    const passed = await this.execute('Ensure apex-node exists', validate);
+    if (!passed) {
+      throw new SfdxError(`${apexNodePath} is missing!. Was the clean too aggressive?`);
+    }
+  }
+
+  private async ensurePluginGenerateTestTemplates(): Promise<void> {
+    const pluginGeneratorTestPath = path.join(
+      this.baseDir,
+      'node_modules',
+      '@salesforce',
+      'plugin-generator',
+      'templates',
+      'sfdxPlugin',
+      'test'
+    );
+    const validate = async (): Promise<boolean> => fs.fileExists(pluginGeneratorTestPath);
+    const passed = await this.execute('Ensure plugin generator test template exists', validate);
+    if (!passed) {
+      throw new SfdxError(`${pluginGeneratorTestPath} is missing!. Was the clean too aggressive?`);
+    }
+  }
+
+  private async ensureTemplatesCommands(): Promise<void> {
+    const templatesPath = path.join(this.baseDir, 'node_modules', '@salesforce', 'plugin-templates');
+    const validate = async (): Promise<boolean> => fs.fileExists(templatesPath);
+    const passed = await this.execute('Ensure templates commands exist', validate);
+    if (!passed) {
+      throw new SfdxError(`${templatesPath} is missing!. Was the doc clean too aggressive?`);
+    }
+  }
+
+  private async ensureNoDistTestsOrMaps(): Promise<void> {
+    const validate = async (): Promise<boolean> => {
+      const files = await fg([`${this.baseDir}/dist/*.test.js`, `${this.baseDir}/dist/*.js.map`]);
+      if (files.length) {
+        this.log(red.bold('Found the following in dist:'));
+        for (const file of files) this.log(file);
+        return false;
+      }
+      return true;
+    };
+    const passed = await this.execute('Ensure no tests or maps in dist', validate);
+    if (!passed) {
+      throw new SfdxError(`Found .test.js and/or .js.map files in ${path.join(this.baseDir, 'dist')}`);
+    }
+  }
+
+  private async ensureNoUnexpectedfiles(): Promise<void> {
+    const validate = async (): Promise<boolean> => {
+      const expectedFileGlobs = [
+        `${this.baseDir}/package.json`,
+        `${this.baseDir}/LICENSE.txt`,
+        `${this.baseDir}/README.md`,
+        `${this.baseDir}/CHANGELOG.md`,
+        `${this.baseDir}/yarn.lock`,
+        `${this.baseDir}/oclif.manifest.json`,
+        `${this.baseDir}/bin/*`,
+        `${this.baseDir}/dist/**/*.js`,
+        `${this.baseDir}/dist/builtins/package.json`,
+        `${this.baseDir}/scripts/clean-for-tarballs`,
+        `${this.baseDir}/scripts/include-sf.js`,
+      ];
+      const expectedFiles = await fg(expectedFileGlobs);
+      const allFiles = await fg([`${this.baseDir}/**/*`, `!${this.baseDir}/node_modules/**/*`]);
+      const unexpectedFiles = allFiles.filter((f) => !expectedFiles.includes(f));
+      if (unexpectedFiles.length) {
+        this.log(red.bold('Found unexpected files in base build dir:'));
+        for (const file of unexpectedFiles) this.log(file);
+        return false;
+      }
+      return true;
+    };
+    const passed = await this.execute('Ensure no unexpected files', validate);
+    if (!passed) {
+      throw new SfdxError('Unexpected file found in base build dir!');
+    }
+  }
+
+  private async ensureSfIsIncluded(): Promise<void> {
+    const validate = async (): Promise<boolean> => {
+      const sfBin = path.join(this.baseDir, 'bin', 'sf');
+      const sfBinExists = await fs.fileExists(sfBin);
+      const sfCmd = path.join(this.baseDir, 'bin', 'sf.cmd');
+      const sfCmdExists = await fs.fileExists(sfCmd);
+      const version = exec(`${sfBin} --version`, { silent: false });
+      const help = exec(`${sfBin} --help`, { silent: false });
+      return sfBinExists && sfCmdExists && version.code === 0 && help.code === 0;
+    };
+    const passed = await this.execute('Ensure sf is included', validate);
+    if (!passed) {
+      throw new SfdxError('sf was not included! Did include-sf.js succeed?');
+    }
+  }
+}

--- a/src/commands/cli/tarballs/verify.ts
+++ b/src/commands/cli/tarballs/verify.ts
@@ -73,7 +73,7 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async execute(msg: string, validate: () => Promise<boolean>): Promise<boolean> {
+  public async execute(msg: string, validate: () => Promise<boolean>): Promise<boolean> {
     this.ux.cli.action.start(`[${this.step}/${this.totalSteps}] ${msg}`);
     if (!(await validate())) {
       this.ux.cli.action.stop(FAILED);
@@ -84,7 +84,7 @@ export default class Verify extends SfdxCommand {
     return true;
   }
 
-  private async ensureNoWebDriverIO(): Promise<void> {
+  public async ensureNoWebDriverIO(): Promise<void> {
     const webDriverIo = path.join(this.baseDir, 'node_modules', 'webdriverio', 'test');
     const validate = async (): Promise<boolean> => {
       return !(await fs.fileExists(webDriverIo));
@@ -95,7 +95,7 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async ensureNoHerokuCliUtilNyc(): Promise<void> {
+  public async ensureNoHerokuCliUtilNyc(): Promise<void> {
     const herokuCliUtil = path.join(
       this.baseDir,
       'node_modules',
@@ -129,7 +129,7 @@ export default class Verify extends SfdxCommand {
    * this leaves us a relatively comfortable maximum windows username length of 48 characters with a hard maximum path length of 144 characters
    * - then scan the cleaned build output directory for paths exceding this threshold, and exit with an error if detected
    */
-  private async ensureWindowsPathLengths(): Promise<void> {
+  public async ensureWindowsPathLengths(): Promise<void> {
     const validate = async (): Promise<boolean> => {
       const warningLength = 124;
       const maxLength = 146;
@@ -160,7 +160,7 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async ensureApexNode(): Promise<void> {
+  public async ensureApexNode(): Promise<void> {
     const apexNodePath = path.join(this.baseDir, 'node_modules', '@salesforce', 'apex-node', 'lib', 'src', 'tests');
     const validate = async (): Promise<boolean> => fs.fileExists(apexNodePath);
     const passed = await this.execute('Ensure apex-node exists', validate);
@@ -169,7 +169,7 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async ensurePluginGenerateTestTemplates(): Promise<void> {
+  public async ensurePluginGenerateTestTemplates(): Promise<void> {
     const pluginGeneratorTestPath = path.join(
       this.baseDir,
       'node_modules',
@@ -186,7 +186,7 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async ensureTemplatesCommands(): Promise<void> {
+  public async ensureTemplatesCommands(): Promise<void> {
     const templatesPath = path.join(this.baseDir, 'node_modules', '@salesforce', 'plugin-templates');
     const validate = async (): Promise<boolean> => fs.fileExists(templatesPath);
     const passed = await this.execute('Ensure templates commands exist', validate);
@@ -195,7 +195,7 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async ensureNoDistTestsOrMaps(): Promise<void> {
+  public async ensureNoDistTestsOrMaps(): Promise<void> {
     const validate = async (): Promise<boolean> => {
       const files = await fg([`${this.baseDir}/dist/*.test.js`, `${this.baseDir}/dist/*.js.map`]);
       if (files.length) {
@@ -211,7 +211,7 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async ensureNoUnexpectedfiles(): Promise<void> {
+  public async ensureNoUnexpectedfiles(): Promise<void> {
     const validate = async (): Promise<boolean> => {
       const expectedFileGlobs = [
         `${this.baseDir}/package.json`,
@@ -242,7 +242,7 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async ensureSfIsIncluded(): Promise<void> {
+  public async ensureSfIsIncluded(): Promise<void> {
     const validate = async (): Promise<boolean> => {
       const sfBin = path.join(this.baseDir, 'bin', 'sf');
       const sfBinExists = await fs.fileExists(sfBin);

--- a/src/commands/cli/tarballs/verify.ts
+++ b/src/commands/cli/tarballs/verify.ts
@@ -61,9 +61,10 @@ export default class Verify extends SfdxCommand {
         // this.ensureSfIsIncluded.bind(this),
       ],
       [CLI.SF]: [
-        this.ensureWindowsPathLengths.bind(this),
         this.ensureNoDistTestsOrMaps.bind(this),
         this.ensureNoUnexpectedfiles.bind(this),
+        // TODO: add this back before R1
+        // this.ensureWindowsPathLengths.bind(this),
       ],
     };
 

--- a/src/commands/cli/versions/inspect.ts
+++ b/src/commands/cli/versions/inspect.ts
@@ -7,11 +7,13 @@
 
 import * as os from 'os';
 import * as path from 'path';
+import * as util from 'util';
 import * as fg from 'fast-glob';
 import { exec } from 'shelljs';
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { fs, Messages, SfdxError } from '@salesforce/core';
 import { green, red, cyan, yellow, bold } from 'chalk';
+import { ensure } from '@salesforce/ts-types';
 import { PackageJson } from '../../../package';
 
 Messages.importMessagesDirectory(__dirname);
@@ -19,8 +21,6 @@ const messages = Messages.loadMessages('@salesforce/plugin-release-management', 
 
 const LEGACY_PATH = 'https://developer.salesforce.com/media/salesforce-cli/sfdx-cli/channels/stable';
 const LEGACY_TOP_LEVEL_PATH = 'https://developer.salesforce.com/media/salesforce-cli';
-const STABLE_PATH = 'https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable';
-const STABLE_RC_PATH = 'https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable-rc';
 const SALESFORCE_DEP_GLOBS = ['@salesforce/**/*', 'salesforce-alm', 'salesforcedx'];
 
 export type Info = {
@@ -49,51 +49,57 @@ export enum Location {
   NPM = 'npm',
 }
 
+export enum CLI {
+  SF = 'sf',
+  SFDX = 'sfdx',
+}
+
 type ArchiveChannel = Extract<Channel, Channel.STABLE | Channel.STABLE_RC | Channel.LEGACY>;
 type Archives = Record<ArchiveChannel, string[]>;
+type ChannelMapping = Record<Location, Record<Channel, Channel>>;
 
 const ARCHIVES: Archives = {
   [Channel.STABLE]: [
-    `${STABLE_PATH}/sfdx-darwin-x64.tar.gz`,
-    `${STABLE_PATH}/sfdx-darwin-x64.tar.xz`,
-    `${STABLE_PATH}/sfdx-linux-arm.tar.gz`,
-    `${STABLE_PATH}/sfdx-linux-arm.tar.xz`,
-    `${STABLE_PATH}/sfdx-linux-x64.tar.gz`,
-    `${STABLE_PATH}/sfdx-linux-x64.tar.xz`,
-    `${STABLE_PATH}/sfdx-win32-x64.tar.gz`,
-    `${STABLE_PATH}/sfdx-win32-x64.tar.xz`,
-    `${STABLE_PATH}/sfdx-win32-x86.tar.gz`,
-    `${STABLE_PATH}/sfdx-win32-x86.tar.xz`,
+    '%s/%s-darwin-x64.tar.gz',
+    '%s/%s-darwin-x64.tar.xz',
+    '%s/%s-linux-arm.tar.gz',
+    '%s/%s-linux-arm.tar.xz',
+    '%s/%s-linux-x64.tar.gz',
+    '%s/%s-linux-x64.tar.xz',
+    '%s/%s-win32-x64.tar.gz',
+    '%s/%s-win32-x64.tar.xz',
+    '%s/%s-win32-x86.tar.gz',
+    '%s/%s-win32-x86.tar.xz',
   ],
   [Channel.STABLE_RC]: [
-    `${STABLE_RC_PATH}/sfdx-darwin-x64.tar.gz`,
-    `${STABLE_RC_PATH}/sfdx-darwin-x64.tar.xz`,
-    `${STABLE_RC_PATH}/sfdx-linux-arm.tar.gz`,
-    `${STABLE_RC_PATH}/sfdx-linux-arm.tar.xz`,
-    `${STABLE_RC_PATH}/sfdx-linux-x64.tar.gz`,
-    `${STABLE_RC_PATH}/sfdx-linux-x64.tar.xz`,
-    `${STABLE_RC_PATH}/sfdx-win32-x64.tar.gz`,
-    `${STABLE_RC_PATH}/sfdx-win32-x64.tar.xz`,
-    `${STABLE_RC_PATH}/sfdx-win32-x86.tar.gz`,
-    `${STABLE_RC_PATH}/sfdx-win32-x86.tar.xz`,
+    '%s/%s-darwin-x64.tar.gz',
+    '%s/%s-darwin-x64.tar.xz',
+    '%s/%s-linux-arm.tar.gz',
+    '%s/%s-linux-arm.tar.xz',
+    '%s/%s-linux-x64.tar.gz',
+    '%s/%s-linux-x64.tar.xz',
+    '%s/%s-win32-x64.tar.gz',
+    '%s/%s-win32-x64.tar.xz',
+    '%s/%s-win32-x86.tar.gz',
+    '%s/%s-win32-x86.tar.xz',
   ],
   [Channel.LEGACY]: [
-    `${LEGACY_PATH}/sfdx-cli-darwin-x64.tar.gz`,
-    `${LEGACY_PATH}/sfdx-cli-darwin-x64.tar.xz`,
-    `${LEGACY_PATH}/sfdx-cli-linux-arm.tar.gz`,
-    `${LEGACY_PATH}/sfdx-cli-linux-arm.tar.xz`,
-    `${LEGACY_PATH}/sfdx-cli-linux-x64.tar.gz`,
-    `${LEGACY_PATH}/sfdx-cli-linux-x64.tar.xz`,
-    `${LEGACY_PATH}/sfdx-cli-windows-x64.tar.gz`,
-    `${LEGACY_PATH}/sfdx-cli-windows-x64.tar.xz`,
-    `${LEGACY_PATH}/sfdx-cli-windows-x86.tar.gz`,
-    `${LEGACY_PATH}/sfdx-cli-windows-x86.tar.xz`,
-    `${LEGACY_TOP_LEVEL_PATH}/sfdx-linux-amd64.tar.gz`,
-    `${LEGACY_TOP_LEVEL_PATH}/sfdx-linux-amd64.tar.xz`,
+    `${LEGACY_PATH}/%s-darwin-x64.tar.gz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-darwin-x64.tar.xz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-linux-arm.tar.gz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-linux-arm.tar.xz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-linux-x64.tar.gz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-linux-x64.tar.xz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-windows-x64.tar.gz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-windows-x64.tar.xz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-windows-x86.tar.gz`, // sfdx-cli
+    `${LEGACY_PATH}/%s-windows-x86.tar.xz`, // sfdx-cli
+    `${LEGACY_TOP_LEVEL_PATH}/%s-linux-amd64.tar.gz`,
+    `${LEGACY_TOP_LEVEL_PATH}/%s-linux-amd64.tar.xz`,
   ],
 };
 
-const CHANNEL_MAPPING: Record<Location, Record<Channel, Channel>> = {
+const CHANNEL_MAPPING: ChannelMapping = {
   [Location.NPM]: {
     [Channel.STABLE_RC]: Channel.LATEST_RC,
     [Channel.STABLE]: Channel.LATEST,
@@ -107,6 +113,19 @@ const CHANNEL_MAPPING: Record<Location, Record<Channel, Channel>> = {
     [Channel.STABLE_RC]: Channel.STABLE_RC,
     [Channel.STABLE]: Channel.STABLE,
     [Channel.LEGACY]: Channel.LEGACY,
+  },
+};
+
+const CLI_META = {
+  [CLI.SFDX]: {
+    npm: 'https://www.npmjs.com/package/sfdx-cli',
+    repoName: 'sfdx-cli',
+    packageName: 'sfdx-cli',
+  },
+  [CLI.SF]: {
+    npm: 'https://www.npmjs.com/package/@salesforce/cli',
+    repoName: 'cli',
+    packageName: '@salesforce/cli',
   },
 };
 
@@ -142,19 +161,37 @@ export default class Inspect extends SfdxCommand {
       required: true,
       multiple: true,
     }),
+    cli: flags.enum({
+      description: messages.getMessage('cli'),
+      options: Object.values(CLI),
+      default: CLI.SFDX,
+      required: true,
+    }),
   };
 
   public workingDir = path.join(os.tmpdir(), 'cli_inspection');
+  public archives: Archives;
 
   public async run(): Promise<Info[]> {
+    const locations = toArray(this.flags.locations) as Location[];
+    const channels = toArray(this.flags.channels) as Channel[];
+
+    if (this.flags.cli === CLI.SF && channels.includes(Channel.LEGACY)) {
+      throw new SfdxError('the sf CLI does not have a legacy channel');
+    }
+
+    if (this.flags.cli === CLI.SF && channels.includes(Channel.STABLE_RC)) {
+      throw new SfdxError('the sf CLI does not have a stable-rc channel');
+    }
+
     this.ux.log(`Working Directory: ${this.workingDir}`);
     // ensure that we are starting with a clean directory
     await fs.rmdir(this.workingDir, { recursive: true });
     await fs.mkdirp(this.workingDir);
 
+    this.initArchives();
+
     const results: Info[] = [];
-    const locations = toArray(this.flags.locations) as Location[];
-    const channels = toArray(this.flags.channels) as Channel[];
 
     if (locations.includes(Location.ARCHIVE)) {
       results.push(...(await this.inspectArchives(channels)));
@@ -169,12 +206,34 @@ export default class Inspect extends SfdxCommand {
     return results;
   }
 
+  private initArchives(): void {
+    const cli = ensure<CLI>(this.flags.cli);
+    const stablePath = `https://developer.salesforce.com/media/salesforce-cli/${cli}/channels/stable`;
+    const stableRcPath = `https://developer.salesforce.com/media/salesforce-cli/${cli}/channels/stable-rc`;
+    this.archives = {} as Archives;
+    for (const [channel, paths] of Object.entries(ARCHIVES)) {
+      if (channel === Channel.LEGACY && cli === CLI.SFDX) {
+        this.archives[channel] = paths.map((p) => {
+          if (p.includes('amd64')) {
+            return util.format(p, this.flags.cli);
+          } else {
+            return util.format(p, CLI_META[this.flags.cli as CLI].packageName);
+          }
+        });
+      } else if (channel === Channel.STABLE) {
+        this.archives[channel] = paths.map((p) => util.format(p, stablePath, this.flags.cli));
+      } else if (channel === Channel.STABLE_RC) {
+        this.archives[channel] = paths.map((p) => util.format(p, stableRcPath, this.flags.cli));
+      }
+    }
+  }
+
   private async inspectArchives(channels: Channel[]): Promise<Info[]> {
     const tarDir = await this.mkdir(this.workingDir, 'tar');
 
     const pathsByChannel = channels.reduce((res, current) => {
       const channel = CHANNEL_MAPPING[Location.ARCHIVE][current] as ArchiveChannel;
-      return Object.assign(res, { [channel]: ARCHIVES[channel] });
+      return Object.assign(res, { [channel]: this.archives[channel] });
     }, {} as Archives);
 
     const results: Info[] = [];
@@ -211,20 +270,21 @@ export default class Inspect extends SfdxCommand {
   }
 
   private async inspectNpm(channels: Channel[]): Promise<Info[]> {
+    const cliMeta = CLI_META[this.flags.cli as CLI];
     const npmDir = await this.mkdir(this.workingDir, 'npm');
     const results: Info[] = [];
     const tags = channels.map((c) => CHANNEL_MAPPING[Location.NPM][c]).filter((c) => c !== Channel.LEGACY);
     for (const tag of tags) {
       this.ux.log(`---- ${Location.NPM} ${tag} ----`);
       const installDir = await this.mkdir(npmDir, tag);
-      const name = `sfdx-cli@${tag}`;
+      const name = `${cliMeta.packageName}@${tag}`;
       this.ux.startSpinner(`Installing: ${cyan(name)}`);
       exec(`npm install ${name}`, { cwd: installDir, silent: true });
       this.ux.stopSpinner();
-      const pkgJson = await this.readPackageJson(path.join(installDir, 'node_modules', 'sfdx-cli'));
+      const pkgJson = await this.readPackageJson(path.join(installDir, 'node_modules', cliMeta.repoName));
       results.push({
         dependencies: await this.getDependencies(installDir),
-        origin: `https://www.npmjs.com/package/sfdx-cli/v/${pkgJson.version}`,
+        origin: `${cliMeta.npm}/v/${pkgJson.version}`,
         channel: tag,
         location: Location.NPM,
         version: pkgJson.version,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
     // "target": "es6"
   },
   "include": ["./src/**/*.ts"]


### PR DESCRIPTION
### What does this PR do?

* Adds a `cli:tarballs:prepare` command to replace the [clean-for-tarballs script in sfdx-cli](https://github.com/salesforcecli/sfdx-cli/blob/main/scripts/clean-for-tarballs). This is required for the `sf` release job 

* Adds a `cli:tarballs:verify` command to replace the [verify-tarballs script in sfdx-cli](https://github.com/salesforcecli/sfdx-cli/blob/main/scripts/verify-tarballs). This is required for the `sf` release job
[](url)
#### `cli:tarballs:prepare`

```
~/code/sfdx-cli [main] : ~/code/plugin-release-management/bin/run cli:tarballs:prepare --help
remove unnecessary files from node_modules

USAGE
  $ sfdx cli:tarballs:prepare [-d] [-t] [--verbose] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]

OPTIONS
  -d, --dryrun                                                                      only show what would be removed from node_modules
  -t, --types                                                                       remove all types (.d.ts) files from node_modules
  --json                                                                            format output as json
  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for this command invocation
  --verbose                                                                         show all files paths being removed

EXAMPLE
  sfdx cli:tarballs:prepare
```

```
~/code/sfdx-cli [main] : ~/code/plugin-release-management/bin/run cli:tarballs:prepare --dryrun
[DRYRUN] Removing: 2722 .md files
[DRYRUN] Removing: 4 .gitattributes files
[DRYRUN] Removing: 42 .eslintrc files
[DRYRUN] Removing: 6 appveyor.yml files
[DRYRUN] Removing: 1 circle.yml files
[DRYRUN] Removing: 9 test directories
[DRYRUN] Removing: 2934 *.map files
[DRYRUN] Removing: 1 jsforce/build directory
```

#### `cli:tarballs:verify`

```
~/code/plugin-release-management [mdonnalley/verify-tarballs] : bin/run cli:tarballs:verify --help
verify that tarballs are ready to be uploaded

USAGE
  $ sfdx cli:tarballs:verify [-c sf|sfdx] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]

OPTIONS
  -c, --cli=(sf|sfdx)                                                               [default: sfdx] the cli to verify
  --json                                                                            format output as json
  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for this command invocation

EXAMPLES
  sfdx cli:tarballs:verify
  sfdx cli:tarballs:verify --cli sfdx
  sfdx cli:tarballs:verify --cli sf
```

```
~/code/sfdx-cli [main] : ~/code/plugin-release-management/bin/run cli:tarballs:verify
[1/8] Ensure webdriverio does not exist... PASSED
[2/8] Ensure heroku-cli-util/.nyc_output does not exist... PASSED
WARNING: Some paths could result in update errors for Windows users with usernames greater than 48 characters!
130 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/authInfoConfig.d.ts
128 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/authInfoConfig.js
132 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configAggregator.d.ts
130 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configAggregator.js
126 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configFile.d.ts
124 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configFile.js
127 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configGroup.d.ts
125 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configGroup.js
127 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configStore.d.ts
125 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configStore.js
130 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/keychainConfig.d.ts
128 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/keychainConfig.js
130 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/orgUsersConfig.d.ts
128 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/orgUsersConfig.js
132 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/sandboxOrgConfig.d.ts
130 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/sandboxOrgConfig.js
127 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/deviceOauthService.d.ts
125 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/deviceOauthService.js
124 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/lifecycleEvents.d.ts
132 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/permissionSetAssignment.d.ts
130 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/permissionSetAssignment.js
125 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/schema/validator.d.ts
132 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/myDomainResolver.d.ts
130 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/myDomainResolver.js
129 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/pollingClient.d.ts
127 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/pollingClient.js
131 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/streamingClient.d.ts
129 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/streamingClient.js
134 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/util/checkLightningDomain.d.ts
132 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/util/checkLightningDomain.js
124 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/messages/encryption.json
137 - node_modules/@salesforce/plugin-apex/node_modules/@salesforce/command/node_modules/@salesforce/core/messages/permissionSetAssignment.json
128 - node_modules/@salesforce/plugin-apex/node_modules/supports-hyperlinks/node_modules/supports-color/node_modules/has-flag/index.js
127 - node_modules/@salesforce/plugin-apex/node_modules/supports-hyperlinks/node_modules/supports-color/node_modules/has-flag/license
132 - node_modules/@salesforce/plugin-apex/node_modules/supports-hyperlinks/node_modules/supports-color/node_modules/has-flag/package.json
126 - node_modules/@salesforce/plugin-generator/node_modules/inquirer/node_modules/string-width/node_modules/ansi-regex/package.json
126 - node_modules/@salesforce/plugin-generator/node_modules/inquirer/node_modules/string-width/node_modules/strip-ansi/package.json
125 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/authRemover.d.ts
128 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/aliases.d.ts
126 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/aliases.js
135 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/authInfoConfig.d.ts
133 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/authInfoConfig.js
127 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/config.d.ts
125 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/config.js
137 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configAggregator.d.ts
135 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configAggregator.js
131 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configFile.d.ts
129 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configFile.js
132 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configGroup.d.ts
130 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configGroup.js
132 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configStore.d.ts
130 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/configStore.js
135 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/keychainConfig.d.ts
133 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/keychainConfig.js
135 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/orgUsersConfig.d.ts
133 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/orgUsersConfig.js
137 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/sandboxOrgConfig.d.ts
135 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/config/sandboxOrgConfig.js
124 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/connection.d.ts
132 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/deviceOauthService.d.ts
130 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/deviceOauthService.js
126 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/keyChainImpl.d.ts
124 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/keyChainImpl.js
129 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/lifecycleEvents.d.ts
127 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/lifecycleEvents.js
137 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/permissionSetAssignment.d.ts
135 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/permissionSetAssignment.js
128 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/schema/printer.d.ts
126 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/schema/printer.js
130 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/schema/validator.d.ts
128 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/schema/validator.js
126 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/secureBuffer.d.ts
124 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/secureBuffer.js
125 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/sfdxProject.d.ts
127 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/client.d.ts
125 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/client.js
137 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/myDomainResolver.d.ts
135 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/myDomainResolver.js
134 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/pollingClient.d.ts
132 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/pollingClient.js
136 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/streamingClient.d.ts
134 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/status/streamingClient.js
139 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/util/checkLightningDomain.d.ts
137 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/util/checkLightningDomain.js
127 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/util/internal.d.ts
125 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/util/internal.js
128 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/webOAuthServer.d.ts
126 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/lib/webOAuthServer.js
125 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/messages/config.json
125 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/messages/crypto.json
129 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/messages/encryption.json
142 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/messages/permissionSetAssignment.json
128 - node_modules/@salesforce/plugin-templates/node_modules/@salesforce/command/node_modules/@salesforce/core/messages/streaming.json
126 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/_stream_duplex.js
131 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/_stream_passthrough.js
128 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/_stream_readable.js
129 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/_stream_transform.js
128 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/_stream_writable.js
139 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/internal/streams/BufferList.js
136 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/internal/streams/destroy.js
143 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/internal/streams/stream-browser.js
135 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/lib/internal/streams/stream.js
124 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/readable-browser.js
124 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/readable-stream/writable-browser.js
125 - node_modules/@salesforce/source-deploy-retrieve/node_modules/archiver-utils/node_modules/string_decoder/lib/string_decoder.js
124 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/lib/archivers/zip/zip-archive-output-stream.js
124 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/duplex-browser.js
128 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/_stream_duplex.js
133 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/_stream_passthrough.js
130 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/_stream_readable.js
131 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/_stream_transform.js
130 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/_stream_writable.js
141 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/internal/streams/BufferList.js
138 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/internal/streams/destroy.js
145 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/internal/streams/stream-browser.js
137 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/lib/internal/streams/stream.js
126 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/readable-browser.js
126 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/readable-stream/writable-browser.js
127 - node_modules/@salesforce/source-deploy-retrieve/node_modules/compress-commons/node_modules/string_decoder/lib/string_decoder.js
124 - node_modules/@salesforce/source-deploy-retrieve/node_modules/jsforce/node_modules/readable-stream/lib/_stream_passthrough.js
132 - node_modules/@salesforce/source-deploy-retrieve/node_modules/jsforce/node_modules/readable-stream/lib/internal/streams/BufferList.js
129 - node_modules/@salesforce/source-deploy-retrieve/node_modules/jsforce/node_modules/readable-stream/lib/internal/streams/destroy.js
136 - node_modules/@salesforce/source-deploy-retrieve/node_modules/jsforce/node_modules/readable-stream/lib/internal/streams/stream-browser.js
128 - node_modules/@salesforce/source-deploy-retrieve/node_modules/jsforce/node_modules/readable-stream/lib/internal/streams/stream.js
124 - node_modules/@salesforce/templates/lib/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/app-to-template-rules.json
128 - node_modules/@salesforce/templates/lib/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/dashboards/basicDashboard.json
124 - node_modules/@salesforce/templates/lib/templates/analytics/waveTemplates/DefaultAnalyticsTemplate/template-to-app-rules.json
130 - node_modules/@salesforce/templates/lib/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.html
128 - node_modules/@salesforce/templates/lib/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.js
137 - node_modules/@salesforce/templates/lib/templates/lightningcomponent/lwc/analyticsDashboardWithStep/analyticsDashboardWithStep.js-meta.xml
[3/8] Ensure windows path lengths... PASSED
[4/8] Ensure apex-node exists... PASSED
[5/8] Ensure plugin generator test template exists... PASSED
[6/8] Ensure templates commands exist... PASSED
[7/8] Ensure no tests or maps in dist... PASSED
[8/8] Ensure no unexpected files... PASSED
```

### What issues does this PR fix or reference?
[skip-validate-pr]