### PR TITLE
feat: support sf releases

### DIFF
--- a/src/commands/cli/tarballs/prepare.ts
+++ b/src/commands/cli/tarballs/prepare.ts
@@ -46,27 +46,29 @@ export default class Verify extends SfdxCommand {
     this.remove(jsForceTestSuite, 'JSforceTestSuite files');
 
     // Module readmes and other markdown docs not found in template directories
-    const markdownFiles = await this.find(`${baseDirGlob}/**/*.md`, { excludeDirectory: 'templates' });
+    const markdownFiles = await this.find(`${baseDirGlob}/**/*.md`, {
+      excludeDirectories: ['templates', 'messages'],
+    });
     this.remove(markdownFiles, '.md files');
 
     // Module .gitignore not found in template directories
-    const gitignore = await this.find(`${baseDirGlob}/**/.gitignore`, { excludeDirectory: 'templates' });
+    const gitignore = await this.find(`${baseDirGlob}/**/.gitignore`, { excludeDirectories: ['templates'] });
     this.remove(gitignore, '.gitignore files');
 
     // Module .gitattributes not found in template directories
-    const gitattributes = await this.find(`${baseDirGlob}/**/.gitattributes`, { excludeDirectory: 'templates' });
+    const gitattributes = await this.find(`${baseDirGlob}/**/.gitattributes`, { excludeDirectories: ['templates'] });
     this.remove(gitattributes, '.gitattributes files');
 
     // Module .eslintrc not found in template directories
-    const eslintrc = await this.find(`${baseDirGlob}/**/.eslintrc`, { excludeDirectory: 'templates' });
+    const eslintrc = await this.find(`${baseDirGlob}/**/.eslintrc`, { excludeDirectories: ['templates'] });
     this.remove(eslintrc, '.eslintrc files');
 
     // Module appveyor.yml not found in template directories
-    const appveyor = await this.find(`${baseDirGlob}/**/appveyor.yml`, { excludeDirectory: 'templates' });
+    const appveyor = await this.find(`${baseDirGlob}/**/appveyor.yml`, { excludeDirectories: ['templates'] });
     this.remove(appveyor, 'appveyor.yml files');
 
     // Module circle.yml not found in template directories
-    const circle = await this.find(`${baseDirGlob}/**/circle.yml`, { excludeDirectory: 'templates' });
+    const circle = await this.find(`${baseDirGlob}/**/circle.yml`, { excludeDirectories: ['templates'] });
     this.remove(circle, 'circle.yml files');
 
     // Module test dirs, except in salesforce-alm, which includes production source code in such a dir
@@ -105,16 +107,21 @@ export default class Verify extends SfdxCommand {
     }
   }
 
-  private async find(globPattern: string, options: fg.Options & { excludeDirectory?: string } = {}): Promise<string[]> {
+  private async find(
+    globPattern: string,
+    options: fg.Options & { excludeDirectories?: string[] } = {}
+  ): Promise<string[]> {
     const patterns = [globPattern];
-    if (options.excludeDirectory) {
-      const parts = globPattern.split('/');
+    if (options.excludeDirectories) {
+      const parts = globPattern.split('/').slice();
       const lastPart = parts.pop();
-      parts.push(options.excludeDirectory, '**', lastPart);
-      const exclusionPattern = `!${parts.join('/')}`;
-      patterns.push(exclusionPattern);
+      for (const dir of options.excludeDirectories) {
+        const patternParts = parts.concat([dir, '**', lastPart]);
+        const exclusionPattern = `!${patternParts.join('/')}`;
+        patterns.push(exclusionPattern);
+      }
     }
-    if (options?.excludeDirectory) delete options.excludeDirectory;
+    if (options?.excludeDirectories) delete options.excludeDirectories;
     return fg(patterns, options);
   }
 

--- a/src/commands/npm/dependencies/pin.ts
+++ b/src/commands/npm/dependencies/pin.ts
@@ -31,7 +31,7 @@ export default class Pin extends SfdxCommand {
     const pkg = packageJson.pinDependencyVersions(this.flags.tag);
 
     if (this.flags.dryrun) {
-      process.emitWarning('Running in --dryrun mode. No changes will be written to the package.json.');
+      this.warn('Running in --dryrun mode. No changes will be written to the package.json.');
     } else {
       packageJson.writePackageJson();
     }
@@ -41,6 +41,7 @@ export default class Pin extends SfdxCommand {
         { key: 'name', label: 'Name' },
         { key: 'version', label: 'Version' },
         { key: 'tag', label: 'Tag' },
+        { key: 'alias', label: 'Alias' },
       ],
     });
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -8,14 +8,14 @@ import * as path from 'path';
 import { exec, pwd } from 'shelljs';
 import { fs, Logger, SfdxError } from '@salesforce/core';
 import { AsyncOptionalCreatable } from '@salesforce/kit';
-import { AnyJson, get } from '@salesforce/ts-types';
+import { AnyJson, get, Nullable } from '@salesforce/ts-types';
 import { Registry } from './registry';
 
 export type PackageJson = {
   name: string;
   version: string;
-  dependencies: AnyJson;
-  devDependencies: AnyJson;
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
   scripts: Record<string, string>;
   files?: string[];
   pinnedDependencies?: string[];
@@ -46,6 +46,7 @@ interface PinnedPackage {
   name: string;
   version: string;
   tag: string;
+  alias: Nullable<string>;
 }
 
 export class Package extends AsyncOptionalCreatable {
@@ -121,11 +122,24 @@ export class Package extends AsyncOptionalCreatable {
         'Pinning package dependencies requires property "pinnedDependencies" to be present in package.json'
       );
     }
-    const dependencies: string[] = this.packageJson.pinnedDependencies;
+    const { pinnedDependencies, dependencies } = this.packageJson;
+    const deps = pinnedDependencies.map((d) => {
+      const version = dependencies[d];
+      if (version.startsWith('npm:')) {
+        return {
+          name: version.replace('npm:', '').replace(/@(\^|~)?[0-9].[0-9].[0-9](.*?)$/, ''),
+          version: version.replace(/(.*?)@/, ''),
+          alias: d,
+        };
+      } else {
+        return { name: d, version, alias: null };
+      }
+    });
+
     const pinnedPackages: PinnedPackage[] = [];
-    dependencies.forEach((name) => {
+    deps.forEach((dep) => {
       // get the 'release' tag version or the version specified by the passed in tag
-      const result = exec(`npm view ${name} dist-tags ${this.registry.getRegistryParameter()} --json`, {
+      const result = exec(`npm view ${dep.name} dist-tags ${this.registry.getRegistryParameter()} --json`, {
         silent: true,
       });
       const versions = JSON.parse(result.stdout) as Record<string, string>;
@@ -139,10 +153,13 @@ export class Package extends AsyncOptionalCreatable {
       const version = versions[tag];
 
       // insert the new hardcoded versions into the dependencies in the project's package.json
-      this.packageJson['dependencies'][name] = version;
-
+      if (dep.alias) {
+        this.packageJson['dependencies'][dep.alias] = `npm:${dep.name}@${version}`;
+      } else {
+        this.packageJson['dependencies'][dep.name] = version;
+      }
       // accumulate information to return
-      pinnedPackages.push({ name, version, tag });
+      pinnedPackages.push({ name: dep.name, version, tag, alias: dep.alias });
     });
 
     return pinnedPackages;

--- a/src/package.ts
+++ b/src/package.ts
@@ -127,7 +127,7 @@ export class Package extends AsyncOptionalCreatable {
       const version = dependencies[d];
       if (version.startsWith('npm:')) {
         return {
-          name: version.replace('npm:', '').replace(/@(\^|~)?[0-9].[0-9].[0-9](.*?)$/, ''),
+          name: version.replace('npm:', '').replace(/@(\^|~)?[0-9]{1,3}(?:.[0-9]{1,3})?(?:.[0-9]{1,3})?(.*?)$/, ''),
           version: version.replace(/(.*?)@/, ''),
           alias: d,
         };

--- a/test/commands/dependencies.pin.test.ts
+++ b/test/commands/dependencies.pin.test.ts
@@ -54,7 +54,7 @@ describe('dependencies:pin', () => {
 
   test
     .do(() => {
-      setupStub();
+      setupStub('auth');
     })
     .stdout()
     .command(['npm:dependencies:pin', '--json'])


### PR DESCRIPTION
### What does this PR do?

- fixes the `cli:tarball:*` commands to support sf releases
- updates `npm:dependencies:pin` to support aliased npm packages

### What issues does this PR fix or reference?
[skip-validate-pr]