### PR TITLE
fix: push to github even if signing verification fails

### DIFF
--- a/src/commands/npm/package/release.ts
+++ b/src/commands/npm/package/release.ts
@@ -121,14 +121,16 @@ export default class Release extends SfdxCommand {
       }
     }
 
-    if (this.flags.sign && this.flags.verify && !this.flags.dryrun) {
-      pkg.printStage('Verify Signed Packaged');
-      pkg.verifySignature();
-    }
-
-    if (!this.flags.dryrun) {
-      pkg.printStage('Push Changes to Git');
-      pkg.pushChangesToGit();
+    try {
+      if (this.flags.sign && this.flags.verify && !this.flags.dryrun) {
+        pkg.printStage('Verify Signed Packaged');
+        pkg.verifySignature();
+      }
+    } finally {
+      if (!this.flags.dryrun) {
+        pkg.printStage('Push Changes to Git');
+        pkg.pushChangesToGit();
+      }
     }
 
     this.ux.log(pkg.getSuccessMessage());


### PR DESCRIPTION
### What does this PR do?

Put the `Push Changes to Git` stage in a finally block in case signing verification fails

### What issues does this PR fix or reference?
[skip-validate-pr]