### PR TITLE
fix: use correct command to verify signed plugin

### DIFF
--- a/src/commands/npm/lerna/release.ts
+++ b/src/commands/npm/lerna/release.ts
@@ -152,8 +152,8 @@ export default class Release extends SfdxCommand {
   }
 
   protected async verifySign(pkgInfo: PackageInfo): Promise<void> {
-    const cmd = 'trust:plugins:verify';
-    const argv = `--npm ${pkgInfo.name}@${pkgInfo.nextVersion} ${pkgInfo.registryParam}`;
+    const cmd = 'plugins:trust:verify';
+    const argv = `--npm ${pkgInfo.name}@${pkgInfo.nextVersion} --registry ${pkgInfo.registryParam}`;
 
     this.ux.log(chalk.dim(`sf-release ${cmd} ${argv}`) + os.EOL);
     try {

--- a/src/commands/npm/lerna/release.ts
+++ b/src/commands/npm/lerna/release.ts
@@ -153,7 +153,7 @@ export default class Release extends SfdxCommand {
 
   protected async verifySign(pkgInfo: PackageInfo): Promise<void> {
     const cmd = 'plugins:trust:verify';
-    const argv = `--npm ${pkgInfo.name}@${pkgInfo.nextVersion} --registry ${pkgInfo.registryParam}`;
+    const argv = `--npm ${pkgInfo.name}@${pkgInfo.nextVersion} ${pkgInfo.registryParam}`;
 
     this.ux.log(chalk.dim(`sf-release ${cmd} ${argv}`) + os.EOL);
     try {

--- a/src/commands/npm/package/release.ts
+++ b/src/commands/npm/package/release.ts
@@ -146,7 +146,7 @@ export default class Release extends SfdxCommand {
 
   protected async verifySign(pkgInfo: PackageInfo): Promise<void> {
     const cmd = 'plugins:trust:verify';
-    const argv = `--npm ${pkgInfo.name}@${pkgInfo.nextVersion} --registry ${pkgInfo.registryParam}`;
+    const argv = `--npm ${pkgInfo.name}@${pkgInfo.nextVersion} ${pkgInfo.registryParam}`;
 
     this.ux.log(chalk.dim(`sf-release ${cmd} ${argv}`) + os.EOL);
     try {

--- a/src/commands/npm/package/release.ts
+++ b/src/commands/npm/package/release.ts
@@ -145,8 +145,8 @@ export default class Release extends SfdxCommand {
   }
 
   protected async verifySign(pkgInfo: PackageInfo): Promise<void> {
-    const cmd = 'trust:plugins:verify';
-    const argv = `--npm ${pkgInfo.name}@${pkgInfo.nextVersion} ${pkgInfo.registryParam}`;
+    const cmd = 'plugins:trust:verify';
+    const argv = `--npm ${pkgInfo.name}@${pkgInfo.nextVersion} --registry ${pkgInfo.registryParam}`;
 
     this.ux.log(chalk.dim(`sf-release ${cmd} ${argv}`) + os.EOL);
     try {


### PR DESCRIPTION
### What does this PR do?

Use `plugins:trust:verify` instead of `trust:plugin:verify` 

### What issues does this PR fix or reference?
@W-9904081@