### PR TITLE
feat: add --skip-ci flag to automerge

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,88 +1,181 @@
 [
-  {
-    "command": "circleci",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["contains-package-type", "json", "loglevel"]
-  },
-  {
-    "command": "circleci:envvar:update",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
-  },
-  {
-    "command": "cli:tarballs:prepare",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "types", "verbose"]
-  },
-  {
-    "command": "cli:tarballs:verify",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["cli", "json", "loglevel", "windows-username-buffer"]
-  },
-  {
-    "command": "cli:versions:inspect",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["channels", "cli", "dependencies", "json", "locations", "loglevel", "salesforce"]
-  },
-  {
-    "command": "dependabot:automerge",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "owner", "repo"]
-  },
-  {
-    "command": "dependabot:consolidate",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": [
-      "base-branch",
-      "dryrun",
-      "ignore",
-      "json",
-      "loglevel",
-      "max-version-bump",
-      "no-pr",
-      "owner",
-      "repo",
-      "target-branch"
-    ]
-  },
-  {
-    "command": "npm:dependencies:pin",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "tag"]
-  },
-  {
-    "command": "npm:lerna:release",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign", "verify"]
-  },
-  {
-    "command": "npm:package:promote",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["candidate", "dryrun", "json", "loglevel", "target"]
-  },
-  {
-    "command": "npm:package:release",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign", "verify"]
-  },
-  {
-    "command": "npm:release:validate",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "verbose"]
-  },
-  {
-    "command": "plugins:trust:verify",
-    "plugin": "@salesforce/plugin-trust",
-    "flags": ["json", "loglevel", "npm", "registry"]
-  },
-  {
-    "command": "repositories",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"]
-  },
-  {
-    "command": "typescript:update",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "target", "version"]
-  }
+    {
+        "command": "circleci",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "contains-package-type",
+            "json",
+            "loglevel"
+        ]
+    },
+    {
+        "command": "circleci:envvar:update",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "envvar",
+            "json",
+            "loglevel",
+            "slug"
+        ]
+    },
+    {
+        "command": "cli:tarballs:prepare",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "types",
+            "verbose"
+        ]
+    },
+    {
+        "command": "cli:tarballs:verify",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "cli",
+            "json",
+            "loglevel",
+            "windows-username-buffer"
+        ]
+    },
+    {
+        "command": "cli:versions:inspect",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "channels",
+            "cli",
+            "dependencies",
+            "json",
+            "locations",
+            "loglevel",
+            "salesforce"
+        ]
+    },
+    {
+        "command": "dependabot:automerge",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "max-version-bump",
+            "owner",
+            "repo",
+            "skip-ci"
+        ]
+    },
+    {
+        "command": "dependabot:consolidate",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "base-branch",
+            "dryrun",
+            "ignore",
+            "json",
+            "loglevel",
+            "max-version-bump",
+            "no-pr",
+            "owner",
+            "repo",
+            "target-branch"
+        ]
+    },
+    {
+        "command": "npm:dependencies:pin",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "tag"
+        ]
+    },
+    {
+        "command": "npm:lerna:release",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "githubrelease",
+            "install",
+            "json",
+            "loglevel",
+            "npmaccess",
+            "npmtag",
+            "sign",
+            "verify"
+        ]
+    },
+    {
+        "command": "npm:package:promote",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "candidate",
+            "dryrun",
+            "json",
+            "loglevel",
+            "target"
+        ]
+    },
+    {
+        "command": "npm:package:release",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "install",
+            "json",
+            "loglevel",
+            "npmaccess",
+            "npmtag",
+            "prerelease",
+            "sign",
+            "verify"
+        ]
+    },
+    {
+        "command": "npm:release:validate",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "verbose"
+        ]
+    },
+    {
+        "command": "plugins:trust:verify",
+        "plugin": "@salesforce/plugin-trust",
+        "flags": [
+            "json",
+            "loglevel",
+            "npm",
+            "registry"
+        ]
+    },
+    {
+        "command": "repositories",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "columns",
+            "csv",
+            "extended",
+            "filter",
+            "json",
+            "loglevel",
+            "no-header",
+            "no-truncate",
+            "output",
+            "sort"
+        ]
+    },
+    {
+        "command": "typescript:update",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "target",
+            "version"
+        ]
+    }
 ]

--- a/messages/dependabot.automerge.json
+++ b/messages/dependabot.automerge.json
@@ -1,5 +1,6 @@
 {
   "description": "automatically merge one green, mergeable PR up to the specified maximum bump type",
+  "skipCi": "add [skip ci] to the merge commit title",
   "examples": [
     "<%= config.bin %> <%= command.id %> --max-version-bump patch",
     "<%= config.bin %> <%= command.id %> --max-version-bump minor",


### PR DESCRIPTION
### What does this PR do?

Adds `--skip-ci` flag to `dependabot:automerge` so that we can avoid building new releases for `sf`

### What issues does this PR fix or reference?
@W-9910648@