### PR TITLE
fix: bump plugin-trust to 1.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@salesforce/command": "^4.1.4",
     "@salesforce/core": "^2.28.1",
     "@salesforce/kit": "^1.5.17",
-    "@salesforce/plugin-trust": "^1.0.9",
+    "@salesforce/plugin-trust": "^1.0.11",
     "@salesforce/ts-types": "^1.4.3",
     "@types/semver": "^7.3.6",
     "@types/sinon": "10.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1048,10 +1048,10 @@
     handlebars "^4.7.3"
     tslib "^1"
 
-"@salesforce/plugin-trust@^1.0.9":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@salesforce/plugin-trust/-/plugin-trust-1.0.10.tgz#d479a8e238cf7508c1db15f379c177ad8b171b8f"
-  integrity sha512-/XY9tRbxofy8k+1l9rIPspaUEEI+VInMZ7p/+Tl3yyONd74yCBHdz9wVb59PAkUI/G460reI8Vt/M29QyoxSXQ==
+"@salesforce/plugin-trust@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@salesforce/plugin-trust/-/plugin-trust-1.0.11.tgz#5a171cbfc364f92ab34b103ae07d074d7b91d541"
+  integrity sha512-smAh1YSznJW1wcJtVLSGPdBsIVmEu6rrHDlRHPnGaHB+iQz1sqlelp7Zsad3wIpYcvuvF0WEcnbD8DDHsdUbSw==
   dependencies:
     "@oclif/config" "^1.17.0"
     "@salesforce/command" "^3.0.5"


### PR DESCRIPTION
### What does this PR do?
Bumps plugin-trust to 1.0.11

### What issues does this PR fix or reference?
@W-10065192@
