### PR TITLE
fix: allow verifying stable-rc channel for sf

### DIFF
--- a/src/commands/cli/versions/inspect.ts
+++ b/src/commands/cli/versions/inspect.ts
@@ -176,10 +176,6 @@ export default class Inspect extends SfdxCommand {
       throw new SfdxError('the sf CLI does not have a legacy channel');
     }
 
-    if (this.flags.cli === CLI.SF && channels.includes(Channel.STABLE_RC)) {
-      throw new SfdxError('the sf CLI does not have a stable-rc channel');
-    }
-
     this.ux.log(`Working Directory: ${this.workingDir}`);
 
     // ensure that we are starting with a clean directory


### PR DESCRIPTION
### What does this PR do?
Removes the check that prevented inspecting the `stable-rc` channel for the `sf` cli.

### What issues does this PR fix or reference?
@W-0@