### PR TITLE
fix: properly skip pr validation

### DIFF
--- a/src/commands/cli/latestrc/build.ts
+++ b/src/commands/cli/latestrc/build.ts
@@ -83,7 +83,7 @@ export default class build extends SfdxCommand {
       head: nextRCVersion,
       base: 'main',
       title: `Release v${nextRCVersion} as latest-rc`,
-      body: 'Building latest-rc @W-0@',
+      body: 'Building latest-rc [skip-validate-pr]',
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

- Use `[skip-validate-pr]` to skip the validation for the PR created by `cli:latestrc:build`

### What issues does this PR fix or reference?
[skip-validate-pr]