### PR TITLE
feat: add cli:tarballs:smoke

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -108,6 +108,16 @@
         ]
     },
     {
+        "command": "cli:tarballs:smoke",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "cli",
+            "json",
+            "loglevel",
+            "verbose"
+        ]
+    },
+    {
         "command": "cli:tarballs:verify",
         "plugin": "@salesforce/plugin-release-management",
         "flags": [

--- a/messages/cli.tarballs.smoke.json
+++ b/messages/cli.tarballs.smoke.json
@@ -1,0 +1,6 @@
+{
+  "description": "smoke tests for the tarballed CLI\n Tests that the CLI and every command can be initialized.",
+  "examples": ["<%= config.bin %> <%= command.id %> --cli sfdx", "<%= config.bin %> <%= command.id %> --cli sf"],
+  "cliFlag": "the cli to install",
+  "verboseFlag": "show the --help output for each command"
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@salesforce/command": "^4.1.4",
     "@salesforce/core": "^2.28.1",
     "@salesforce/kit": "^1.5.17",
-    "@salesforce/plugin-trust": "^1.0.9",
+    "@salesforce/plugin-trust": "^1.0.11",
     "@salesforce/ts-types": "^1.4.3",
     "@types/semver": "^7.3.6",
     "@types/sinon": "10.0.6",

--- a/src/commands/cli/schemas/collect.ts
+++ b/src/commands/cli/schemas/collect.ts
@@ -44,7 +44,7 @@ export class SchemaUtils {
   }
 }
 
-export default class collect extends SfdxCommand {
+export default class Collect extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly flagsConfig: FlagsConfig = {};

--- a/src/commands/cli/tarballs/smoke.ts
+++ b/src/commands/cli/tarballs/smoke.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import * as chalk from 'chalk';
+import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { Messages, SfdxError } from '@salesforce/core';
+import { ensure } from '@salesforce/ts-types';
+import { exec } from 'shelljs';
+import { CLI } from '../../../types';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-release-management', 'cli.tarballs.smoke');
+
+export default class SmokeTest extends SfdxCommand {
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly flagsConfig: FlagsConfig = {
+    cli: flags.string({
+      description: messages.getMessage('cliFlag'),
+      options: Object.values(CLI),
+      char: 'c',
+      required: true,
+    }),
+    verbose: flags.builtin({
+      description: messages.getMessage('verboseFlag'),
+    }),
+  };
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  public async run(): Promise<void> {
+    const cli = ensure<CLI>(this.flags.cli);
+    const executables = [path.join('tmp', cli, 'bin', cli)];
+    if (cli === CLI.SFDX) {
+      executables.push(path.join('tmp', cli, 'bin', CLI.SF));
+    }
+    for (const executable of executables) {
+      this.smokeTest(executable);
+    }
+  }
+
+  private smokeTest(executable: string): void {
+    this.execute(executable, '--version');
+    this.execute(executable, '--help');
+    this.execute(executable, 'plugins --core');
+    this.initializeAllCommands(executable);
+  }
+
+  private initializeAllCommands(executable: string): void {
+    for (const command of this.getAllCommands(executable)) {
+      if (this.flags.verbose) {
+        this.execute(executable, `${command} --help`);
+      } else {
+        try {
+          this.execute(executable, `${command} --help`, true);
+          this.log(`${executable} ${command} --help ${chalk.green('PASSED')}`);
+        } catch (err) {
+          this.log(`${executable} ${command} --help ${chalk.red('FAILED')}`);
+          throw err;
+        }
+      }
+    }
+  }
+
+  private getAllCommands(executable: string): string[] {
+    if (path.basename(executable) === CLI.SF) this.execute(executable, 'plugins:install @oclif/plugin-commands@^2');
+    const commandsJson = JSON.parse(this.execute(executable, 'commands --json', true)) as Array<{ id: string }>;
+    return commandsJson.map((c) => c.id);
+  }
+
+  private execute(executable: string, args: string, silent = false): string {
+    const command = `${executable} ${args}`;
+    const result = exec(command, { silent: true });
+    if (result.code === 0) {
+      if (!silent) {
+        this.ux.styledHeader(command);
+        this.log(result.stdout);
+      }
+      return result.stdout;
+    } else {
+      throw new SfdxError(`Failed: ${command}`);
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1048,10 +1048,10 @@
     handlebars "^4.7.3"
     tslib "^1"
 
-"@salesforce/plugin-trust@^1.0.9":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@salesforce/plugin-trust/-/plugin-trust-1.0.10.tgz#d479a8e238cf7508c1db15f379c177ad8b171b8f"
-  integrity sha512-/XY9tRbxofy8k+1l9rIPspaUEEI+VInMZ7p/+Tl3yyONd74yCBHdz9wVb59PAkUI/G460reI8Vt/M29QyoxSXQ==
+"@salesforce/plugin-trust@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/@salesforce/plugin-trust/-/plugin-trust-1.0.11.tgz#5a171cbfc364f92ab34b103ae07d074d7b91d541"
+  integrity sha512-smAh1YSznJW1wcJtVLSGPdBsIVmEu6rrHDlRHPnGaHB+iQz1sqlelp7Zsad3wIpYcvuvF0WEcnbD8DDHsdUbSw==
   dependencies:
     "@oclif/config" "^1.17.0"
     "@salesforce/command" "^3.0.5"


### PR DESCRIPTION
### What does this PR do?

Adds `cli:tarballs:smoke` to replace existing smoke tests ([sf](https://github.com/salesforcecli/cli/blob/main/package.json#L132) and [sfdx](https://github.com/salesforcecli/sfdx-cli/blob/main/package.json#L222))

```
~/repos/salesforcecli/plugin-release-management [mdonnalley/smoke-test] : bin/run cli:tarballs:smoke --help
smoke tests for the tarballed CLI

USAGE
  $ sfdx cli:tarballs:smoke -c <string> [--verbose] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]

OPTIONS
  -c, --cli=sf|sfdx                                                                 (required) the cli to install
  --json                                                                            format output as json
  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for this command invocation
  --verbose                                                                         show the --help output for each command

DESCRIPTION
  Tests that the CLI and every command can be initialized.

EXAMPLES
  sfdx cli:tarballs:smoke --cli sfdx
  sfdx cli:tarballs:smoke --cli sf
```

These smoke tests test the following:
- `--version`
- `--help`
- `plugins --core`
- `--help` on every command

### What issues does this PR fix or reference?
@W-10190536@