### PR TITLE
Do not allow automatic major version bumps

### DIFF
--- a/src/commands/npm/release/validate.ts
+++ b/src/commands/npm/release/validate.ts
@@ -6,6 +6,7 @@
  */
 
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
+import { SfdxError } from '@salesforce/core';
 import { isMonoRepo, LernaRepo } from '../../../repository';
 import { Package } from '../../../package';
 import { CommitInspection, inspectCommits } from '../../../inspectCommits';
@@ -44,8 +45,9 @@ export default class Validate extends SfdxCommand {
     }
     const majorBump = responses.some((resp) => !!resp.isMajorBump);
     if (majorBump) {
-      this.ux.warn(
-        'Major version bump detected. You must manually update the version in the package.json to release a new major version.'
+      throw new SfdxError(
+        'Major version bump detected. You must manually update the version in the package.json to release a new major version.',
+        'MajorBumpDetected'
       );
     }
     const shouldRelease = responses.some((resp) => !!resp.shouldRelease) && !majorBump;

--- a/src/commands/npm/release/validate.ts
+++ b/src/commands/npm/release/validate.ts
@@ -17,6 +17,7 @@ type PackageCommits = CommitInspection & {
 
 type Response = {
   shouldRelease: boolean;
+  majorBump: boolean;
   packages?: PackageCommits[];
 };
 
@@ -41,8 +42,14 @@ export default class Validate extends SfdxCommand {
       });
       responses.push(response);
     }
-    const shouldRelease = responses.some((resp) => !!resp.shouldRelease);
+    const majorBump = responses.some((resp) => !!resp.isMajorBump);
+    if (majorBump) {
+      this.ux.warn(
+        'Major version bump detected. You must manually update the version in the package.json to release a new major version.'
+      );
+    }
+    const shouldRelease = responses.some((resp) => !!resp.shouldRelease) && !majorBump;
     this.ux.log(shouldRelease.toString());
-    return this.flags.verbose ? { shouldRelease, packages: responses } : { shouldRelease };
+    return this.flags.verbose ? { shouldRelease, majorBump, packages: responses } : { shouldRelease, majorBump };
   }
 }

--- a/src/inspectCommits.ts
+++ b/src/inspectCommits.ts
@@ -78,27 +78,27 @@ export async function inspectCommits(pkg: Package, lerna = false): Promise<Commi
 
   const releasableCommits: Commit[] = [];
   const unreleasableCommits: Commit[] = [];
-  let isMajorBump = false;
+  let majorBumpRequired = false;
   for (const commit of commits) {
     const headerIndicatesMajorChange = !!commit.header && commit.header.includes('!');
     const bodyIndicatesMajorChange = !!commit.body && commit.body.includes('BREAKING');
     const typeIsSkippable = skippableCommitTypes.includes(commit.type);
-    const isMajorChange = bodyIndicatesMajorChange || headerIndicatesMajorChange;
-    const isReleasable = !typeIsSkippable || isMajorChange;
+    const isBreakingChange = bodyIndicatesMajorChange || headerIndicatesMajorChange;
+    const isReleasable = !typeIsSkippable || isBreakingChange;
     if (isReleasable) {
       releasableCommits.push(commit);
     } else {
       unreleasableCommits.push(commit);
     }
 
-    if (isMajorChange && !isMajorBump) isMajorBump = true;
+    if (isBreakingChange) majorBumpRequired = true;
   }
 
   return {
     releasableCommits,
     unreleasableCommits,
     nextVersionIsHardcoded,
-    isMajorBump,
+    isMajorBump: majorBumpRequired,
     shouldRelease: nextVersionIsHardcoded || releasableCommits.length > 0,
   };
 }

--- a/src/package.ts
+++ b/src/package.ts
@@ -88,9 +88,21 @@ export class Package extends AsyncOptionalCreatable {
     return (await fs.readJson(pkgJsonPath)) as PackageJson;
   }
 
+  /**
+   * Retrieve the npm package info using `npm view`
+   *
+   * It'll first try to find the package with the version listed in the package.json
+   * If that version doesn't exist, it'll find the version tagged as latest
+   */
   public retrieveNpmPackage(): NpmPackage {
-    const result = exec(`npm view ${this.name} ${this.registry.getRegistryParameter()} --json`, { silent: true });
-    return result.code === 0 ? (JSON.parse(result.stdout) as NpmPackage) : null;
+    let result = exec(
+      `npm view ${this.name}@${this.packageJson.version} ${this.registry.getRegistryParameter()} --json`,
+      { silent: true }
+    );
+    if (!result.stdout) {
+      result = exec(`npm view ${this.name} ${this.registry.getRegistryParameter()} --json`, { silent: true });
+    }
+    return !result.stdout ? (JSON.parse(result.stdout) as NpmPackage) : null;
   }
 
   public validateNextVersion(): VersionValidation {

--- a/test/inspectCommits.test.ts
+++ b/test/inspectCommits.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as os from 'os';
+import * as shelljs from 'shelljs';
+import { expect } from 'chai';
+import { testSetup } from '@salesforce/core/lib/testSetup';
+import * as sinon from 'sinon';
+import { stubMethod } from '@salesforce/ts-sinon';
+import { inspectCommits } from '../src/inspectCommits';
+import { Package } from '../src/package';
+
+const $$ = testSetup();
+
+describe('inspectCommits', () => {
+  const packageJson = { name: 'foobar', version: '2.0.0' };
+
+  function buildCommitLog(...commitTypes: string[]): string {
+    const commitHash = '2b5efa1bed4934a9f5e3d1b8ed4c411ff4121261';
+    let final = '';
+    for (const type of commitTypes) {
+      final += `${type}: made some changes${os.EOL}${os.EOL}-hash-${os.EOL}${commitHash}${os.EOL}SPLIT${os.EOL}`;
+    }
+    return final;
+  }
+
+  function stubs(commitLog: string, nextVersionIsHardcoded = false) {
+    stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(Promise.resolve(packageJson));
+    stubMethod($$.SANDBOX, Package.prototype, 'nextVersionIsHardcoded').returns(nextVersionIsHardcoded);
+    stubMethod($$.SANDBOX, shelljs, 'exec')
+      .withArgs(sinon.match('npm view'))
+      .returns({ stdout: JSON.stringify(packageJson) })
+      .withArgs(sinon.match('npm config'))
+      .returns({ stdout: 'https://registry.npmjs.org/' })
+      .withArgs(sinon.match('git tag'), { silent: true })
+      .returns({ stdout: 'v1.0.0' })
+      .withArgs(sinon.match('git log'), { silent: true })
+      .returns({ stdout: commitLog });
+  }
+
+  it('should recommend release when "feat" commits are present', async () => {
+    const commitLog = buildCommitLog('feat', 'chore');
+    stubs(commitLog);
+    const pkg = await Package.create();
+    const inspection = await inspectCommits(pkg);
+    expect(inspection.shouldRelease).to.be.true;
+  });
+
+  it('should recommend release when "fix" commits are present', async () => {
+    const commitLog = buildCommitLog('fix', 'chore');
+    stubs(commitLog);
+    const pkg = await Package.create();
+    const inspection = await inspectCommits(pkg);
+    expect(inspection.shouldRelease).to.be.true;
+  });
+
+  it('should recommend release when the next version is hardcoded', async () => {
+    const commitLog = buildCommitLog('chore', 'docs', 'ci');
+    stubs(commitLog, true);
+    const pkg = await Package.create();
+    const inspection = await inspectCommits(pkg);
+    expect(inspection.shouldRelease).to.be.true;
+  });
+
+  it('should not recommend release when no "fix" or "feat" commits are present', async () => {
+    const commitLog = buildCommitLog('chore', 'docs', 'ci');
+    stubs(commitLog);
+    const pkg = await Package.create();
+    const inspection = await inspectCommits(pkg);
+    expect(inspection.shouldRelease).to.be.false;
+  });
+
+  it('should indicate a major version bump when a breaking commit is found', async () => {
+    const commitLog = buildCommitLog('chore', 'feat!');
+    stubs(commitLog);
+    const pkg = await Package.create();
+    const inspection = await inspectCommits(pkg);
+    expect(inspection.isMajorBump).to.be.true;
+  });
+});

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -27,6 +27,11 @@ describe('Package', () => {
           version: '1.0.0',
         })
       );
+      stubMethod($$.SANDBOX, Package.prototype, 'retrieveNpmPackage').returns({
+        name: pkgName,
+        version: '1.0.0',
+        versions: ['0.0.1', '0.0.5', '1.0.0'],
+      });
     });
 
     it('should read the package.json in the current working directory', async () => {


### PR DESCRIPTION
### What does this PR do?

Updates `npm:release:validate` to fail if a major version bump is detected. 

Once this is merged, any major version bump will need to be done manually in the package.json

### What issues does this PR fix or reference?
@W-10203815@