### PR TITLE
fix: allow any script to be included in tarball

### DIFF
--- a/src/commands/cli/tarballs/verify.ts
+++ b/src/commands/cli/tarballs/verify.ts
@@ -243,8 +243,7 @@ export default class Verify extends SfdxCommand {
         `${this.baseDir}/bin/*`,
         `${this.baseDir}/dist/**/*.js`,
         `${this.baseDir}/dist/builtins/package.json`,
-        `${this.baseDir}/scripts/clean-for-tarballs`,
-        `${this.baseDir}/scripts/include-sf.js`,
+        `${this.baseDir}/scripts/*`,
         `${this.baseDir}/sf/**/*`,
       ];
       const expectedFiles = await fg(expectedFileGlobs);


### PR DESCRIPTION
### What does this PR do?

Allow any file under `scripts` to be included in the tarball

### What issues does this PR fix or reference?
@W-10121246@