### PR TITLE
feat: add --merge-method flag to automerge

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2021, Salesforce.com, Inc.
+Copyright (c) 2022, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,268 +1,142 @@
 [
-    {
-        "command": "channel:promote",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "candidate",
-            "cli",
-            "dryrun",
-            "indexes",
-            "json",
-            "loglevel",
-            "maxage",
-            "platform",
-            "sha",
-            "target",
-            "targets",
-            "version",
-            "xz"
-        ]
-    },
-    {
-        "command": "circleci",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "contains-package-type",
-            "json",
-            "loglevel"
-        ]
-    },
-    {
-        "command": "circleci:envvar:create",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "envvar",
-            "json",
-            "loglevel",
-            "slug"
-        ]
-    },
-    {
-        "command": "circleci:envvar:update",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "envvar",
-            "json",
-            "loglevel",
-            "slug"
-        ]
-    },
-    {
-        "command": "cli:install:test",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "channel",
-            "cli",
-            "json",
-            "loglevel",
-            "method"
-        ]
-    },
-    {
-        "command": "cli:latestrc:build",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "json",
-            "loglevel",
-            "rctag"
-        ]
-    },
-    {
-        "command": "cli:releasenotes",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "cli",
-            "json",
-            "loglevel",
-            "markdown",
-            "since"
-        ]
-    },
-    {
-        "command": "cli:schemas:collect",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "json",
-            "loglevel"
-        ]
-    },
-    {
-        "command": "cli:schemas:compare",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "json",
-            "loglevel"
-        ]
-    },
-    {
-        "command": "cli:tarballs:prepare",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "json",
-            "loglevel",
-            "types",
-            "verbose"
-        ]
-    },
-    {
-        "command": "cli:tarballs:smoke",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "cli",
-            "json",
-            "loglevel",
-            "verbose"
-        ]
-    },
-    {
-        "command": "cli:tarballs:verify",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "cli",
-            "json",
-            "loglevel",
-            "windows-username-buffer"
-        ]
-    },
-    {
-        "command": "cli:versions:inspect",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "channels",
-            "cli",
-            "dependencies",
-            "json",
-            "locations",
-            "loglevel",
-            "salesforce"
-        ]
-    },
-    {
-        "command": "dependabot:automerge",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "json",
-            "loglevel",
-            "max-version-bump",
-            "owner",
-            "repo",
-            "skip-ci"
-        ]
-    },
-    {
-        "command": "dependabot:consolidate",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "base-branch",
-            "dryrun",
-            "ignore",
-            "json",
-            "loglevel",
-            "max-version-bump",
-            "no-pr",
-            "owner",
-            "repo",
-            "target-branch"
-        ]
-    },
-    {
-        "command": "npm:dependencies:pin",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "json",
-            "loglevel",
-            "tag"
-        ]
-    },
-    {
-        "command": "npm:lerna:release",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "githubrelease",
-            "install",
-            "json",
-            "loglevel",
-            "npmaccess",
-            "npmtag",
-            "sign",
-            "verify"
-        ]
-    },
-    {
-        "command": "npm:package:promote",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "candidate",
-            "dryrun",
-            "json",
-            "loglevel",
-            "target"
-        ]
-    },
-    {
-        "command": "npm:package:release",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "dryrun",
-            "install",
-            "json",
-            "loglevel",
-            "npmaccess",
-            "npmtag",
-            "prerelease",
-            "sign",
-            "verify"
-        ]
-    },
-    {
-        "command": "npm:release:validate",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "json",
-            "loglevel",
-            "verbose"
-        ]
-    },
-    {
-        "command": "plugins:trust:verify",
-        "plugin": "@salesforce/plugin-trust",
-        "flags": [
-            "json",
-            "loglevel",
-            "npm",
-            "registry"
-        ]
-    },
-    {
-        "command": "repositories",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "columns",
-            "csv",
-            "extended",
-            "filter",
-            "json",
-            "loglevel",
-            "no-header",
-            "no-truncate",
-            "output",
-            "sort"
-        ]
-    },
-    {
-        "command": "typescript:update",
-        "plugin": "@salesforce/plugin-release-management",
-        "flags": [
-            "json",
-            "loglevel",
-            "target",
-            "version"
-        ]
-    }
+  {
+    "command": "channel:promote",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": [
+      "candidate",
+      "cli",
+      "dryrun",
+      "indexes",
+      "json",
+      "loglevel",
+      "maxage",
+      "platform",
+      "sha",
+      "target",
+      "targets",
+      "version",
+      "xz"
+    ]
+  },
+  {
+    "command": "circleci",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["contains-package-type", "json", "loglevel"]
+  },
+  {
+    "command": "circleci:envvar:create",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
+  },
+  {
+    "command": "circleci:envvar:update",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
+  },
+  {
+    "command": "cli:install:test",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["channel", "cli", "json", "loglevel", "method"]
+  },
+  {
+    "command": "cli:latestrc:build",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel", "rctag"]
+  },
+  {
+    "command": "cli:releasenotes",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["cli", "json", "loglevel", "markdown", "since"]
+  },
+  {
+    "command": "cli:schemas:collect",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel"]
+  },
+  {
+    "command": "cli:schemas:compare",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel"]
+  },
+  {
+    "command": "cli:tarballs:prepare",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "json", "loglevel", "types", "verbose"]
+  },
+  {
+    "command": "cli:tarballs:smoke",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["cli", "json", "loglevel", "verbose"]
+  },
+  {
+    "command": "cli:tarballs:verify",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["cli", "json", "loglevel", "windows-username-buffer"]
+  },
+  {
+    "command": "cli:versions:inspect",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["channels", "cli", "dependencies", "json", "locations", "loglevel", "salesforce"]
+  },
+  {
+    "command": "dependabot:automerge",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "owner", "repo", "skip-ci", "squash"]
+  },
+  {
+    "command": "dependabot:consolidate",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": [
+      "base-branch",
+      "dryrun",
+      "ignore",
+      "json",
+      "loglevel",
+      "max-version-bump",
+      "no-pr",
+      "owner",
+      "repo",
+      "target-branch"
+    ]
+  },
+  {
+    "command": "npm:dependencies:pin",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "json", "loglevel", "tag"]
+  },
+  {
+    "command": "npm:lerna:release",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign", "verify"]
+  },
+  {
+    "command": "npm:package:promote",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["candidate", "dryrun", "json", "loglevel", "target"]
+  },
+  {
+    "command": "npm:package:release",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign", "verify"]
+  },
+  {
+    "command": "npm:release:validate",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel", "verbose"]
+  },
+  {
+    "command": "plugins:trust:verify",
+    "plugin": "@salesforce/plugin-trust",
+    "flags": ["json", "loglevel", "npm", "registry"]
+  },
+  {
+    "command": "repositories",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"]
+  },
+  {
+    "command": "typescript:update",
+    "plugin": "@salesforce/plugin-release-management",
+    "flags": ["json", "loglevel", "target", "version"]
+  }
 ]

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -81,7 +81,7 @@
   {
     "command": "dependabot:automerge",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "owner", "repo", "skip-ci", "squash"]
+    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "merge-method", "owner", "repo", "skip-ci"]
   },
   {
     "command": "dependabot:consolidate",

--- a/messages/dependabot.automerge.json
+++ b/messages/dependabot.automerge.json
@@ -1,6 +1,7 @@
 {
   "description": "automatically merge one green, mergeable PR up to the specified maximum bump type",
   "skipCi": "add [skip ci] to the merge commit title",
+  "squash": "squash the commits into one commit and merge it into the base branch",
   "examples": [
     "<%= config.bin %> <%= command.id %> --max-version-bump patch",
     "<%= config.bin %> <%= command.id %> --max-version-bump minor",

--- a/messages/dependabot.automerge.json
+++ b/messages/dependabot.automerge.json
@@ -1,7 +1,7 @@
 {
   "description": "automatically merge one green, mergeable PR up to the specified maximum bump type",
   "skipCi": "add [skip ci] to the merge commit title",
-  "squash": "squash the commits into one commit and merge it into the base branch",
+  "mergeMethod": "merge method to use",
   "examples": [
     "<%= config.bin %> <%= command.id %> --max-version-bump patch",
     "<%= config.bin %> <%= command.id %> --max-version-bump minor",

--- a/src/commands/dependabot/automerge.ts
+++ b/src/commands/dependabot/automerge.ts
@@ -68,9 +68,10 @@ export default class AutoMerge extends SfdxCommand {
       char: 's',
       default: false,
     }),
-    squash: flags.boolean({
-      description: messages.getMessage('squash'),
-      default: false,
+    'merge-method': flags.enum({
+      description: messages.getMessage('mergeMethod'),
+      options: ['merge', 'squash', 'rebase'],
+      default: 'merge',
     }),
   };
 
@@ -126,13 +127,11 @@ export default class AutoMerge extends SfdxCommand {
       this.ux.log(`merging ${prToMerge.number.toString()} | ${prToMerge.title}`);
       const opts: octokitOpts = {
         ...this.baseRepoObject,
+        merge_method: this.flags.mergeMethod,
         pull_number: prToMerge.number,
       };
       if (this.flags['skip-ci']) {
         opts.commit_title = `Merge pull request #${prToMerge.number} from ${prToMerge.head.ref} [skip ci]`;
-      }
-      if (this.flags.squash) {
-        opts.merge_method = 'squash';
       }
       const mergeResult = await this.octokit.request('PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge', opts);
       this.ux.logJson(mergeResult);


### PR DESCRIPTION
### What does this PR do?
Adds `--merge-method` flag to the `dependabot:automerge` command so that PRs can be merged in repos with merge commit option disabled.

GH docs: https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request

### What issues does this PR fix or reference?
@W-0@