### PR TITLE
fix: remove invalid flag reference for `merge-method`

### DIFF
--- a/src/commands/dependabot/automerge.ts
+++ b/src/commands/dependabot/automerge.ts
@@ -127,7 +127,7 @@ export default class AutoMerge extends SfdxCommand {
       this.ux.log(`merging ${prToMerge.number.toString()} | ${prToMerge.title}`);
       const opts: octokitOpts = {
         ...this.baseRepoObject,
-        merge_method: this.flags.mergeMethod,
+        merge_method: this.flags['merge-method'],
         pull_number: prToMerge.number,
       };
       if (this.flags['skip-ci']) {


### PR DESCRIPTION
### What does this PR do?
Removes ref to an invalid flag (typo) that was causing `merge_method: undefined` in the payload even with `--merge-method squash`. 

### What issues does this PR fix or reference?
@W-0@