### PR TITLE
feat: optionally skip resolutions and pinnedDeps in latestrc build

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,142 +1,271 @@
 [
-  {
-    "command": "channel:promote",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": [
-      "candidate",
-      "cli",
-      "dryrun",
-      "indexes",
-      "json",
-      "loglevel",
-      "maxage",
-      "platform",
-      "sha",
-      "target",
-      "targets",
-      "version",
-      "xz"
-    ]
-  },
-  {
-    "command": "circleci",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["contains-package-type", "json", "loglevel"]
-  },
-  {
-    "command": "circleci:envvar:create",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
-  },
-  {
-    "command": "circleci:envvar:update",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
-  },
-  {
-    "command": "cli:install:test",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["channel", "cli", "json", "loglevel", "method"]
-  },
-  {
-    "command": "cli:latestrc:build",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "rctag"]
-  },
-  {
-    "command": "cli:releasenotes",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["cli", "json", "loglevel", "markdown", "since"]
-  },
-  {
-    "command": "cli:schemas:collect",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel"]
-  },
-  {
-    "command": "cli:schemas:compare",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel"]
-  },
-  {
-    "command": "cli:tarballs:prepare",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "types", "verbose"]
-  },
-  {
-    "command": "cli:tarballs:smoke",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["cli", "json", "loglevel", "verbose"]
-  },
-  {
-    "command": "cli:tarballs:verify",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["cli", "json", "loglevel", "windows-username-buffer"]
-  },
-  {
-    "command": "cli:versions:inspect",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["channels", "cli", "dependencies", "json", "locations", "loglevel", "salesforce"]
-  },
-  {
-    "command": "dependabot:automerge",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "merge-method", "owner", "repo", "skip-ci"]
-  },
-  {
-    "command": "dependabot:consolidate",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": [
-      "base-branch",
-      "dryrun",
-      "ignore",
-      "json",
-      "loglevel",
-      "max-version-bump",
-      "no-pr",
-      "owner",
-      "repo",
-      "target-branch"
-    ]
-  },
-  {
-    "command": "npm:dependencies:pin",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "tag"]
-  },
-  {
-    "command": "npm:lerna:release",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "githubrelease", "install", "json", "loglevel", "npmaccess", "npmtag", "sign", "verify"]
-  },
-  {
-    "command": "npm:package:promote",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["candidate", "dryrun", "json", "loglevel", "target"]
-  },
-  {
-    "command": "npm:package:release",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign", "verify"]
-  },
-  {
-    "command": "npm:release:validate",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "verbose"]
-  },
-  {
-    "command": "plugins:trust:verify",
-    "plugin": "@salesforce/plugin-trust",
-    "flags": ["json", "loglevel", "npm", "registry"]
-  },
-  {
-    "command": "repositories",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"]
-  },
-  {
-    "command": "typescript:update",
-    "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "target", "version"]
-  }
+    {
+        "command": "channel:promote",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "candidate",
+            "cli",
+            "dryrun",
+            "indexes",
+            "json",
+            "loglevel",
+            "maxage",
+            "platform",
+            "sha",
+            "target",
+            "targets",
+            "version",
+            "xz"
+        ]
+    },
+    {
+        "command": "circleci",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "contains-package-type",
+            "json",
+            "loglevel"
+        ]
+    },
+    {
+        "command": "circleci:envvar:create",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "envvar",
+            "json",
+            "loglevel",
+            "slug"
+        ]
+    },
+    {
+        "command": "circleci:envvar:update",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "envvar",
+            "json",
+            "loglevel",
+            "slug"
+        ]
+    },
+    {
+        "command": "cli:install:test",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "channel",
+            "cli",
+            "json",
+            "loglevel",
+            "method"
+        ]
+    },
+    {
+        "command": "cli:latestrc:build",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "pinned-deps",
+            "rctag",
+            "resolutions"
+        ]
+    },
+    {
+        "command": "cli:releasenotes",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "cli",
+            "json",
+            "loglevel",
+            "markdown",
+            "since"
+        ]
+    },
+    {
+        "command": "cli:schemas:collect",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel"
+        ]
+    },
+    {
+        "command": "cli:schemas:compare",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel"
+        ]
+    },
+    {
+        "command": "cli:tarballs:prepare",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "types",
+            "verbose"
+        ]
+    },
+    {
+        "command": "cli:tarballs:smoke",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "cli",
+            "json",
+            "loglevel",
+            "verbose"
+        ]
+    },
+    {
+        "command": "cli:tarballs:verify",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "cli",
+            "json",
+            "loglevel",
+            "windows-username-buffer"
+        ]
+    },
+    {
+        "command": "cli:versions:inspect",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "channels",
+            "cli",
+            "dependencies",
+            "json",
+            "locations",
+            "loglevel",
+            "salesforce"
+        ]
+    },
+    {
+        "command": "dependabot:automerge",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "max-version-bump",
+            "merge-method",
+            "owner",
+            "repo",
+            "skip-ci"
+        ]
+    },
+    {
+        "command": "dependabot:consolidate",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "base-branch",
+            "dryrun",
+            "ignore",
+            "json",
+            "loglevel",
+            "max-version-bump",
+            "no-pr",
+            "owner",
+            "repo",
+            "target-branch"
+        ]
+    },
+    {
+        "command": "npm:dependencies:pin",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "json",
+            "loglevel",
+            "tag"
+        ]
+    },
+    {
+        "command": "npm:lerna:release",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "githubrelease",
+            "install",
+            "json",
+            "loglevel",
+            "npmaccess",
+            "npmtag",
+            "sign",
+            "verify"
+        ]
+    },
+    {
+        "command": "npm:package:promote",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "candidate",
+            "dryrun",
+            "json",
+            "loglevel",
+            "target"
+        ]
+    },
+    {
+        "command": "npm:package:release",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "dryrun",
+            "install",
+            "json",
+            "loglevel",
+            "npmaccess",
+            "npmtag",
+            "prerelease",
+            "sign",
+            "verify"
+        ]
+    },
+    {
+        "command": "npm:release:validate",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "verbose"
+        ]
+    },
+    {
+        "command": "plugins:trust:verify",
+        "plugin": "@salesforce/plugin-trust",
+        "flags": [
+            "json",
+            "loglevel",
+            "npm",
+            "registry"
+        ]
+    },
+    {
+        "command": "repositories",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "columns",
+            "csv",
+            "extended",
+            "filter",
+            "json",
+            "loglevel",
+            "no-header",
+            "no-truncate",
+            "output",
+            "sort"
+        ]
+    },
+    {
+        "command": "typescript:update",
+        "plugin": "@salesforce/plugin-release-management",
+        "flags": [
+            "json",
+            "loglevel",
+            "target",
+            "version"
+        ]
+    }
 ]

--- a/messages/cli.latestrc.build.json
+++ b/messages/cli.latestrc.build.json
@@ -1,6 +1,8 @@
 {
   "description": "creates a PR to the repository property defined in the package.json to release a latest-rc build",
   "flags": {
-    "rctag": "the tag name that corresponds to the npm RC build, usually latest-rc or stable-rc"
+    "rctag": "the tag name that corresponds to the npm RC build, usually latest-rc or stable-rc",
+    "resolutions": "bump the versions of packages listed in the resolutions section",
+    "pinnedDeps": "bump the versions of the packages listed in the pinnedDependencies section"
   }
 }

--- a/src/commands/cli/latestrc/build.ts
+++ b/src/commands/cli/latestrc/build.ts
@@ -23,6 +23,16 @@ export default class build extends SfdxCommand {
       description: messages.getMessage('flags.rctag'),
       default: 'latest-rc',
     }),
+    resolutions: flags.boolean({
+      description: messages.getMessage('flags.resolutions'),
+      default: true,
+      allowNo: true,
+    }),
+    'pinned-deps': flags.boolean({
+      description: messages.getMessage('flags.pinnedDeps'),
+      default: true,
+      allowNo: true,
+    }),
   };
 
   public async run(): Promise<void> {
@@ -51,12 +61,17 @@ export default class build extends SfdxCommand {
     repo.package.packageJson.version = nextRCVersion;
 
     // bump resolution deps
-    this.ux.log('bumping resolutions in the package.json to their "latest"');
-    repo.package.bumpResolutions('latest');
+    if (this.flags.resolutions) {
+      this.ux.log('bumping resolutions in the package.json to their "latest"');
+      repo.package.bumpResolutions('latest');
+    }
 
     // pin the pinned dependencies
-    this.ux.log('pinning dependencies in pinnedDependencies to "latest-rc"');
-    repo.package.pinDependencyVersions('latest-rc');
+    if (this.flags['pinned-deps']) {
+      this.ux.log('pinning dependencies in pinnedDependencies to "latest-rc"');
+      repo.package.pinDependencyVersions('latest-rc');
+    }
+
     repo.package.writePackageJson();
 
     this.exec('yarn install');


### PR DESCRIPTION
### What does this PR do?

Provides option in `cli:latestrc:build` to skip bumping either the resolutions or the pinned dependencies

### What issues does this PR fix or reference?
[skip-validate-pr]