### PR TITLE
fix: handle scenario where no versions exist yet

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -252,7 +252,7 @@ export class Package extends AsyncOptionalCreatable {
    * published to the registry
    */
   public nextVersionIsHardcoded(): boolean {
-    return !this.npmPackage.versions.includes(this.packageJson.version);
+    return !(this.npmPackage.versions ?? []).includes(this.packageJson.version);
   }
 
   public hasScript(scriptName: string): boolean {


### PR DESCRIPTION
### What does this PR do?

Updates `Package.nextVersionIsHardcoded` to handle scenario where a package hasn't been released yet.

### What issues does this PR fix or reference?
[skip-validate-pr]