### PR TITLE
Improve install tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
             parameters:
               os:
                 - linux
-                - windows
+                # - windows
               node_version:
                 - latest
                 - lts

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lib
 .nyc_output
 coverage
 test_session*
+test-results.json
 
 # generated docs
 docs

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -57,7 +57,8 @@
             "cli",
             "json",
             "loglevel",
-            "method"
+            "method",
+            "output-file"
         ]
     },
     {

--- a/messages/cli.install.test.json
+++ b/messages/cli.install.test.json
@@ -9,5 +9,6 @@
   ],
   "cliFlag": "the cli to install",
   "methodFlag": "the installation method to use",
-  "channelFlag": "the channel to install from"
+  "channelFlag": "the channel to install from",
+  "outputFileFlag": "the file to write the JSON results to (must be .json)"
 }


### PR DESCRIPTION
### What does this PR do?

- Updates `cli:install:test` to write to a .json file instead of supporting --json. This makes CI much better since you can see all the logs while still having a way to parse json results
- Test for `sf` on `sfdx` installer tests
- Report failure when npm or aws are not available

### What issues does this PR fix or reference?
@W-10293558@