### PR TITLE
fix: update the mac installer package name

### DIFF
--- a/src/commands/cli/install/test.ts
+++ b/src/commands/cli/install/test.ts
@@ -293,7 +293,8 @@ class Installer extends Method.Base {
   }
 
   public async darwin(): Promise<Results> {
-    const pkg = `${this.options.cli}.pkg`;
+    // TODO: Add test for ...-arm64.pkg when we have a way to test on M1 machines in CircleCI.
+    const pkg = `${this.options.cli}-x64.pkg`;
     const url = `${this.s3.directory}/channels/${this.options.channel}/${pkg}`;
     const location = path.join(this.options.directory, pkg);
     await this.s3.download(url, location);


### PR DESCRIPTION
### What does this PR do?
Updates the mac installer package name to match what it will be after https://github.com/oclif/oclif/pull/849 is merged and our CLIs are updated to use oclif@^3.

### What issues does this PR fix or reference?
@W-10844187@