### PR TITLE
Ew/allow build rc without push

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -41,7 +41,7 @@
   {
     "command": "cli:latestrc:build",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "patch", "pinned-deps", "rctag", "resolutions"]
+    "flags": ["build-only", "json", "loglevel", "patch", "pinned-deps", "rctag", "resolutions"]
   },
   {
     "command": "cli:releasenotes",

--- a/messages/cli.latestrc.build.json
+++ b/messages/cli.latestrc.build.json
@@ -4,6 +4,7 @@
     "rctag": "the tag name that corresponds to the npm RC build, usually latest-rc or stable-rc",
     "resolutions": "bump the versions of packages listed in the resolutions section",
     "pinnedDeps": "bump the versions of the packages listed in the pinnedDependencies section",
-    "patch": "bump the release as a patch of an existing version, not a new minor version"
+    "patch": "bump the release as a patch of an existing version, not a new minor version",
+    "buildOnly": "only build the latest rc, do not git add/commit/push"
   }
 }

--- a/src/commands/cli/latestrc/build.ts
+++ b/src/commands/cli/latestrc/build.ts
@@ -50,7 +50,7 @@ export default class build extends SfdxCommand {
     if (pushChangesToGitHub) {
       auth = ensureString(
         new Env().getString('GH_TOKEN') ?? new Env().getString('GITHUB_TOKEN'),
-        'GH_TOKEN is required to be set in the environment'
+        'The GH_TOKEN env var is required to push changes to GitHub. Use the --build-only flag to skip GitHub operations (a manual push will then be needed)'
       );
     }
 


### PR DESCRIPTION
### What does this PR do?
Allows you to run `sfdx cli:latestrc:build --build-only` to just build the RC (does not add/commit/push). 
Useful for creating RCs locally so that you dont need to set a `GH_TOKEN`