### PR TITLE
`--only` flag for the build-latest-rc command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -41,7 +41,7 @@
   {
     "command": "cli:latestrc:build",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["build-only", "json", "loglevel", "patch", "pinned-deps", "rctag", "resolutions"]
+    "flags": ["build-only", "json", "loglevel", "only", "patch", "pinned-deps", "rctag", "resolutions"]
   },
   {
     "command": "cli:releasenotes",

--- a/messages/cli.latestrc.build.json
+++ b/messages/cli.latestrc.build.json
@@ -1,9 +1,16 @@
 {
   "description": "creates a PR to the repository property defined in the package.json to release a latest-rc build",
+  "examples": [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --patch",
+    "<%= config.bin %> <%= command.id %> --build-only",
+    "<%= config.bin %> <%= command.id %> --only @salesforce/plugin-source,@salesforce/plugin-info@1.2.3,@sf/config"
+  ],
   "flags": {
     "rctag": "the tag name that corresponds to the npm RC build, usually latest-rc or stable-rc",
     "resolutions": "bump the versions of packages listed in the resolutions section",
     "pinnedDeps": "bump the versions of the packages listed in the pinnedDependencies section",
+    "only": "only bump the version of the packages passed in, uses latest if version is not provided",
     "patch": "bump the release as a patch of an existing version, not a new minor version",
     "buildOnly": "only build the latest rc, do not git add/commit/push"
   }

--- a/src/commands/cli/latestrc/build.ts
+++ b/src/commands/cli/latestrc/build.ts
@@ -12,7 +12,7 @@ import { ensureString } from '@salesforce/ts-types';
 import { Env } from '@salesforce/kit';
 import { Octokit } from '@octokit/core';
 import { bold } from 'chalk';
-import { Messages } from '@salesforce/core';
+import { Messages, SfdxError } from '@salesforce/core';
 import { SinglePackageRepo } from '../../../repository';
 
 Messages.importMessagesDirectory(__dirname);
@@ -82,7 +82,13 @@ export default class build extends SfdxCommand {
 
     if (only) {
       this.ux.log(`bumping the following dependencies only: ${only.join(', ')}`);
-      repo.package.bumpDependencyVersions(only);
+      const bumped = repo.package.bumpDependencyVersions(only);
+
+      if (!bumped.length) {
+        throw new SfdxError(
+          'No version changes made. Confirm you are passing the correct dependency and version to --only.'
+        );
+      }
     } else {
       // bump resolution deps
       if (this.flags.resolutions) {

--- a/src/commands/cli/latestrc/build.ts
+++ b/src/commands/cli/latestrc/build.ts
@@ -4,6 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+
+import * as os from 'os';
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { exec, ExecOptions } from 'shelljs';
 import { ensureString } from '@salesforce/ts-types';
@@ -18,6 +20,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-release-management', 
 
 export default class build extends SfdxCommand {
   public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly flagsConfig: FlagsConfig = {
     rctag: flags.string({
       description: messages.getMessage('flags.rctag'),
@@ -31,6 +34,9 @@ export default class build extends SfdxCommand {
       description: messages.getMessage('flags.resolutions'),
       default: true,
       allowNo: true,
+    }),
+    only: flags.array({
+      description: messages.getMessage('flags.only'),
     }),
     'pinned-deps': flags.boolean({
       description: messages.getMessage('flags.pinnedDeps'),
@@ -72,18 +78,24 @@ export default class build extends SfdxCommand {
     repo.package.setNextVersion(nextRCVersion);
     repo.package.packageJson.version = nextRCVersion;
 
-    // bump resolution deps
-    if (this.flags.resolutions) {
-      this.ux.log('bumping resolutions in the package.json to their "latest"');
-      repo.package.bumpResolutions('latest');
-    }
+    const only = this.flags.only as string[];
 
-    // pin the pinned dependencies
-    if (this.flags['pinned-deps']) {
-      this.ux.log('pinning dependencies in pinnedDependencies to "latest-rc"');
-      repo.package.pinDependencyVersions('latest-rc');
-    }
+    if (only) {
+      this.ux.log(`bumping the following dependencies only: ${only.join(', ')}`);
+      repo.package.bumpDependencyVersions(only);
+    } else {
+      // bump resolution deps
+      if (this.flags.resolutions) {
+        this.ux.log('bumping resolutions in the package.json to their "latest"');
+        repo.package.bumpResolutions('latest');
+      }
 
+      // pin the pinned dependencies
+      if (this.flags['pinned-deps']) {
+        this.ux.log('pinning dependencies in pinnedDependencies to "latest-rc"');
+        repo.package.pinDependencyVersions('latest-rc');
+      }
+    }
     repo.package.writePackageJson();
 
     this.exec('yarn install');

--- a/src/package.ts
+++ b/src/package.ts
@@ -235,7 +235,7 @@ export class Package extends AsyncOptionalCreatable {
         depInfo.finalVersion = `npm:${depInfo.packageName}@${depInfo.finalVersion}`;
       }
 
-      this.packageJson['dependencies'][depInfo.dependencyName] = depInfo.finalVersion;
+      this.packageJson.dependencies[depInfo.dependencyName] = depInfo.finalVersion;
 
       return depInfo;
     });
@@ -314,9 +314,9 @@ export class Package extends AsyncOptionalCreatable {
 
       // insert the new hardcoded versions into the dependencies in the project's package.json
       if (dep.alias) {
-        this.packageJson['dependencies'][dep.alias] = `npm:${dep.name}@${version}`;
+        this.packageJson.dependencies[dep.alias] = `npm:${dep.name}@${version}`;
       } else {
-        this.packageJson['dependencies'][dep.name] = version;
+        this.packageJson.dependencies[dep.name] = version;
       }
       // accumulate information to return
       pinnedPackages.push({ name: dep.name, version, tag, alias: dep.alias });

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -150,4 +150,134 @@ describe('Package', () => {
       expect(pkg.nextVersionIsAvailable()).to.equal(true);
     });
   });
+
+  describe('getDependencyInfo', () => {
+    beforeEach(() => {
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
+        Promise.resolve({
+          name: pkgName,
+          version: '1.0.0',
+          dependencies: {
+            '@sf/info': 'npm:@salesforce/plugin-info@2.0.1',
+            '@salesforce/plugin-config': '1.2.3',
+          },
+        })
+      );
+    });
+
+    it('should find dependency using an npm alias', async () => {
+      const pkg = await Package.create();
+      const dependency = pkg.getDependencyInfo('@sf/info');
+
+      expect(dependency).to.deep.equal({
+        dependencyName: '@sf/info',
+        packageName: '@salesforce/plugin-info',
+        alias: 'npm:@salesforce/plugin-info@2.0.1',
+        currentVersion: '2.0.1',
+      });
+    });
+
+    it('should find an npm alias with a package name', async () => {
+      const pkg = await Package.create();
+      const dependency = pkg.getDependencyInfo('@salesforce/plugin-info');
+
+      expect(dependency).to.deep.equal({
+        dependencyName: '@sf/info',
+        packageName: '@salesforce/plugin-info',
+        alias: 'npm:@salesforce/plugin-info@2.0.1',
+        currentVersion: '2.0.1',
+      });
+    });
+
+    it('should find a dependency using a package name', async () => {
+      const pkg = await Package.create();
+      const dependency = pkg.getDependencyInfo('@salesforce/plugin-config');
+
+      expect(dependency).to.deep.equal({
+        dependencyName: '@salesforce/plugin-config',
+        packageName: '@salesforce/plugin-config',
+        alias: null,
+        currentVersion: '1.2.3',
+      });
+    });
+  });
+
+  describe.only('bumpDependencyVersions', () => {
+    beforeEach(() => {
+      stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
+        Promise.resolve({
+          name: pkgName,
+          version: '1.0.0',
+          dependencies: {
+            '@sf/info': 'npm:@salesforce/plugin-info@2.0.1',
+            '@salesforce/plugin-config': '1.2.3',
+            'left-pad': '1.1.1',
+          },
+        })
+      );
+      stubMethod($$.SANDBOX, Package.prototype, 'getDistTags').returns({
+        latest: '9.9.9',
+      });
+    });
+
+    it('should look up latest version if not provided', async () => {
+      const pkg = await Package.create();
+      const results = pkg.bumpDependencyVersions(['@sf/info', '@salesforce/plugin-config']);
+
+      expect(results).to.deep.equal([
+        {
+          dependencyName: '@sf/info',
+          packageName: '@salesforce/plugin-info',
+          alias: 'npm:@salesforce/plugin-info@2.0.1',
+          currentVersion: '2.0.1',
+          finalVersion: 'npm:@salesforce/plugin-info@9.9.9',
+        },
+        {
+          dependencyName: '@salesforce/plugin-config',
+          packageName: '@salesforce/plugin-config',
+          alias: null,
+          currentVersion: '1.2.3',
+          finalVersion: '9.9.9',
+        },
+      ]);
+    });
+
+    it('should used passed in version', async () => {
+      const pkg = await Package.create();
+      const results = pkg.bumpDependencyVersions(['@salesforce/plugin-info@7.7.7']);
+
+      expect(results).to.deep.equal([
+        {
+          dependencyName: '@sf/info',
+          packageName: '@salesforce/plugin-info',
+          alias: 'npm:@salesforce/plugin-info@2.0.1',
+          currentVersion: '2.0.1',
+          finalVersion: 'npm:@salesforce/plugin-info@7.7.7',
+        },
+      ]);
+    });
+
+    it('should work with non-namespaced package', async () => {
+      const pkg = await Package.create();
+      const results = pkg.bumpDependencyVersions(['left-pad']);
+
+      expect(results).to.deep.equal([
+        {
+          dependencyName: 'left-pad',
+          packageName: 'left-pad',
+          alias: null,
+          currentVersion: '1.1.1',
+          finalVersion: '9.9.9',
+        },
+      ]);
+    });
+
+    it('should update package.json', async () => {
+      const pkg = await Package.create();
+      pkg.bumpDependencyVersions(['@sf/info@2.2.2', '@salesforce/plugin-config@3.3.3']);
+
+      expect(pkg.packageJson.dependencies['@sf/info']).to.equal('npm:@salesforce/plugin-info@2.2.2');
+      expect(pkg.packageJson.dependencies['@salesforce/plugin-config']).to.equal('3.3.3');
+    });
+  });
 });

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -202,7 +202,7 @@ describe('Package', () => {
     });
   });
 
-  describe.only('bumpDependencyVersions', () => {
+  describe('bumpDependencyVersions', () => {
     beforeEach(() => {
       stubMethod($$.SANDBOX, Package.prototype, 'readPackageJson').returns(
         Promise.resolve({

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -167,7 +167,8 @@ describe('Package', () => {
 
     it('should find dependency using an npm alias', async () => {
       const pkg = await Package.create();
-      const dependency = pkg.getDependencyInfo('@sf/info');
+      const deps = pkg.packageJson.dependencies;
+      const dependency = pkg.getDependencyInfo('@sf/info', deps);
 
       expect(dependency).to.deep.equal({
         dependencyName: '@sf/info',
@@ -179,7 +180,8 @@ describe('Package', () => {
 
     it('should find an npm alias with a package name', async () => {
       const pkg = await Package.create();
-      const dependency = pkg.getDependencyInfo('@salesforce/plugin-info');
+      const deps = pkg.packageJson.dependencies;
+      const dependency = pkg.getDependencyInfo('@salesforce/plugin-info', deps);
 
       expect(dependency).to.deep.equal({
         dependencyName: '@sf/info',
@@ -191,7 +193,8 @@ describe('Package', () => {
 
     it('should find a dependency using a package name', async () => {
       const pkg = await Package.create();
-      const dependency = pkg.getDependencyInfo('@salesforce/plugin-config');
+      const deps = pkg.packageJson.dependencies;
+      const dependency = pkg.getDependencyInfo('@salesforce/plugin-config', deps);
 
       expect(dependency).to.deep.equal({
         dependencyName: '@salesforce/plugin-config',
@@ -212,6 +215,9 @@ describe('Package', () => {
             '@sf/info': 'npm:@salesforce/plugin-info@2.0.1',
             '@salesforce/plugin-config': '1.2.3',
             'left-pad': '1.1.1',
+          },
+          resolutions: {
+            '@salesforce/source-deploy-retrieve': '1.0.0',
           },
         })
       );
@@ -272,12 +278,26 @@ describe('Package', () => {
       ]);
     });
 
-    it('should update package.json', async () => {
+    it('should return an empty array if all versions are already up to date', async () => {
+      const pkg = await Package.create();
+      const results = pkg.bumpDependencyVersions(['@sf/info@2.0.1', '@salesforce/plugin-config@1.2.3']);
+
+      expect(results).to.deep.equal([]);
+    });
+
+    it('should update dependencies in package.json', async () => {
       const pkg = await Package.create();
       pkg.bumpDependencyVersions(['@sf/info@2.2.2', '@salesforce/plugin-config@3.3.3']);
 
       expect(pkg.packageJson.dependencies['@sf/info']).to.equal('npm:@salesforce/plugin-info@2.2.2');
       expect(pkg.packageJson.dependencies['@salesforce/plugin-config']).to.equal('3.3.3');
+    });
+
+    it('should update resolutions in package.json', async () => {
+      const pkg = await Package.create();
+      pkg.bumpDependencyVersions(['@salesforce/source-deploy-retrieve@1.0.1']);
+
+      expect(pkg.packageJson.resolutions['@salesforce/source-deploy-retrieve']).to.equal('1.0.1');
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Allows the build-latest-rc script to *only* update the packages that are passed to the `--only` flag. This is especially useful for `patch` releases

### What issues does this PR fix or reference?
[@W-11462358@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-11462358)