### PR TITLE
Sm/regex bug on dependabot pr titles

### DIFF
--- a/src/commands/dependabot/automerge.ts
+++ b/src/commands/dependabot/automerge.ts
@@ -100,6 +100,7 @@ export default class AutoMerge extends SfdxCommand {
       (pr) =>
         pr.state === 'open' &&
         pr.user.login === 'dependabot[bot]' &&
+        /bump .+ from [0-9]+.[0-9]+.[0-9] to [0-9]+.[0-9]+.[0-9]+$/.test(pr.title) &&
         meetsVersionCriteria(pr.title, this.flags['max-version-bump'])
     ) as PullRequest[];
 

--- a/src/dependabot.ts
+++ b/src/dependabot.ts
@@ -24,15 +24,10 @@ const inclusionMap = {
 };
 
 export const meetsVersionCriteria = (title: string, maxVersionBump: BumpType): boolean => {
-  try {
-    const versionsRegex = /[0-9]+.[0-9]+.[0-9]+/g;
-    const [from, to] = title.match(versionsRegex);
-    const bumpType = diff(from, to) as BumpType;
-    return inclusionMap[maxVersionBump].includes(bumpType);
-  } catch (e) {
-    // example of unparsable title: https://github.com/salesforcecli/eslint-plugin-sf-plugin/pull/25
-    return false;
-  }
+  const versionsRegex = /[0-9]+.[0-9]+.[0-9]+/g;
+  const [from, to] = title.match(versionsRegex);
+  const bumpType = diff(from, to) as BumpType;
+  return inclusionMap[maxVersionBump].includes(bumpType);
 };
 
 export const maxVersionBumpFlag = flags.enum({

--- a/src/dependabot.ts
+++ b/src/dependabot.ts
@@ -17,19 +17,22 @@ type BumpType = Extract<ReleaseType, 'major' | 'minor' | 'patch'>;
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/plugin-release-management', 'dependabot.consolidate', ['maxVersionBump']);
 
+const inclusionMap = {
+  major: ['major', 'minor', 'patch'] as BumpType[],
+  minor: ['minor', 'patch'] as BumpType[],
+  patch: ['patch'] as BumpType[],
+};
+
 export const meetsVersionCriteria = (title: string, maxVersionBump: BumpType): boolean => {
-  const versionsRegex = /[0-9]+.[0-9]+.[0-9]+/g;
-  const [from, to] = title.match(versionsRegex);
-
-  const bumpType = diff(from, to) as BumpType;
-  const inclusionMap = {
-    major: ['major', 'minor', 'patch'] as BumpType[],
-    minor: ['minor', 'patch'] as BumpType[],
-    patch: ['patch'] as BumpType[],
-  };
-
-  const includeBumps = inclusionMap[maxVersionBump];
-  return includeBumps.includes(bumpType);
+  try {
+    const versionsRegex = /[0-9]+.[0-9]+.[0-9]+/g;
+    const [from, to] = title.match(versionsRegex);
+    const bumpType = diff(from, to) as BumpType;
+    return inclusionMap[maxVersionBump].includes(bumpType);
+  } catch (e) {
+    // example of unparsable title: https://github.com/salesforcecli/eslint-plugin-sf-plugin/pull/25
+    return false;
+  }
 };
 
 export const maxVersionBumpFlag = flags.enum({


### PR DESCRIPTION
### What does this PR do?
existing code expects dependabot PR titles like `chore(deps-dev): bump eslint-plugin-prettier from 4.0.0 to 4.2.1`
it can't handle the multi-bump like `chore(deps-dev): bump eslint and @types/eslint` (doesn't yet read body for version info)

this skips those

### What issues does this PR fix or reference?
@W-0@