### PR TITLE
Sm/publish from tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ sfdx plugins
 - [`sfdx dependabot:consolidate -m major|minor|patch -b <string> -t <string> [--ignore <array>] [-d] [--no-pr] [-r <string> -o <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-dependabotconsolidate--m-majorminorpatch--b-string--t-string---ignore-array--d---no-pr--r-string--o-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx npm:dependencies:pin [-d] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-npmdependenciespin--d--t-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx npm:package:promote -c <string> [-d] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-npmpackagepromote--c-string--d--t-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-- [`sfdx npm:package:release [-d] [-s] [-t <string>] [-a <string>] [--install] [--prerelease <string>] [--verify] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-npmpackagerelease--d--s--t-string--a-string---install---prerelease-string---verify---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+- [`sfdx npm:package:release [-d] [-s] [-t <string>] [-a <string>] [--install] [--prerelease <string>] [--verify] [--githubtag <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-npmpackagerelease--d--s--t-string--a-string---install---prerelease-string---verify---githubtag-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx npm:release:validate [--verbose] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-npmreleasevalidate---verbose---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx plugins:trust:verify -n <string> [-r <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-pluginstrustverify--n-string--r-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 - [`sfdx`](#sfdx)
@@ -164,7 +164,7 @@ EXAMPLES
   $ sfdx channel:promote --candidate latest-rc --target latest --platform win --platform mac
 ```
 
-_See code: [src/commands/channel/promote.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/channel/promote.ts)_
+_See code: [src/commands/channel/promote.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/channel/promote.ts)_
 
 ## `sfdx circleci [-t plugin|library|orb] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -188,7 +188,7 @@ EXAMPLES
   $ sfdx circleci -t plugin
 ```
 
-_See code: [src/commands/circleci/index.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/circleci/index.ts)_
+_See code: [src/commands/circleci/index.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/circleci/index.ts)_
 
 ## `sfdx circleci:envvar:create -e <string> [-s <string>] [--dryrun] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -225,7 +225,7 @@ EXAMPLES
   $ sfdx circleci -t plugin | sfdx circleci:envvar:create -e 'MY_ENV_VAR' -e 'MY_OTHER_ENV_VAR'
 ```
 
-_See code: [src/commands/circleci/envvar/create.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/circleci/envvar/create.ts)_
+_See code: [src/commands/circleci/envvar/create.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/circleci/envvar/create.ts)_
 
 ## `sfdx circleci:envvar:update -e <string> [-s <string>] [--dryrun] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -262,7 +262,7 @@ EXAMPLES
   $ sfdx circleci -t plugin | sfdx circleci:envvar:update -e 'MY_ENV_VAR' -e 'MY_OTHER_ENV_VAR'
 ```
 
-_See code: [src/commands/circleci/envvar/update.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/circleci/envvar/update.ts)_
+_See code: [src/commands/circleci/envvar/update.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/circleci/envvar/update.ts)_
 
 ## `sfdx cli:install:test -c <string> -m <string> [--channel <string>] [--output-file <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -305,7 +305,7 @@ EXAMPLES
   $ sfdx cli:install:test --cli sf --method tarball --channel stable-rc
 ```
 
-_See code: [src/commands/cli/install/test.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/install/test.ts)_
+_See code: [src/commands/cli/install/test.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/install/test.ts)_
 
 ## `sfdx cli:latestrc:build [--rctag <string>] [--build-only] [--resolutions] [--only <array>] [--pinned-deps] [--patch] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -351,7 +351,7 @@ EXAMPLES
   $ sfdx cli:latestrc:build --only @salesforce/plugin-source,@salesforce/plugin-info@1.2.3,@sf/config
 ```
 
-_See code: [src/commands/cli/latestrc/build.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/latestrc/build.ts)_
+_See code: [src/commands/cli/latestrc/build.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/latestrc/build.ts)_
 
 ## `sfdx cli:releasenotes -c <string> [-s <string>] [-m] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -393,7 +393,7 @@ EXAMPLES
   $ sfdx cli:releasenotes --cli sf --markdown > changes.md
 ```
 
-_See code: [src/commands/cli/releasenotes.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/releasenotes.ts)_
+_See code: [src/commands/cli/releasenotes.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/releasenotes.ts)_
 
 ## `sfdx cli:schemas:collect [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -415,7 +415,7 @@ EXAMPLES
   $ sfdx cli:schemas:collect
 ```
 
-_See code: [src/commands/cli/schemas/collect.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/schemas/collect.ts)_
+_See code: [src/commands/cli/schemas/collect.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/schemas/collect.ts)_
 
 ## `sfdx cli:schemas:compare [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -437,7 +437,7 @@ EXAMPLES
   $ sfdx cli:schemas:compare
 ```
 
-_See code: [src/commands/cli/schemas/compare.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/schemas/compare.ts)_
+_See code: [src/commands/cli/schemas/compare.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/schemas/compare.ts)_
 
 ## `sfdx cli:tarballs:prepare [-d] [-t] [--verbose] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -465,7 +465,7 @@ EXAMPLES
   $ sfdx cli:tarballs:prepare
 ```
 
-_See code: [src/commands/cli/tarballs/prepare.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/tarballs/prepare.ts)_
+_See code: [src/commands/cli/tarballs/prepare.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/tarballs/prepare.ts)_
 
 ## `sfdx cli:tarballs:smoke -c <string> [--verbose] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -496,7 +496,7 @@ EXAMPLES
   $ sfdx cli:tarballs:smoke --cli sf
 ```
 
-_See code: [src/commands/cli/tarballs/smoke.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/tarballs/smoke.ts)_
+_See code: [src/commands/cli/tarballs/smoke.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/tarballs/smoke.ts)_
 
 ## `sfdx cli:tarballs:verify [-c sf|sfdx] [-w <number>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -527,7 +527,7 @@ EXAMPLES
   $ sfdx cli:tarballs:verify --cli sf
 ```
 
-_See code: [src/commands/cli/tarballs/verify.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/tarballs/verify.ts)_
+_See code: [src/commands/cli/tarballs/verify.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/tarballs/verify.ts)_
 
 ## `sfdx cli:versions:inspect -c <string> -l <string> --cli sf|sfdx [-d <string>] [-s] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -588,7 +588,7 @@ EXAMPLES
   $ sfdx cli:versions:inspect -l npm -c latest -d chalk -s
 ```
 
-_See code: [src/commands/cli/versions/inspect.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/cli/versions/inspect.ts)_
+_See code: [src/commands/cli/versions/inspect.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/cli/versions/inspect.ts)_
 
 ## `sfdx dependabot:automerge -m major|minor|patch [-r <string> -o <string>] [-d] [-s] [--merge-method merge|squash|rebase] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -630,7 +630,7 @@ EXAMPLES
   $ sfdx dependabot:automerge --max-version-bump major
 ```
 
-_See code: [src/commands/dependabot/automerge.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/dependabot/automerge.ts)_
+_See code: [src/commands/dependabot/automerge.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/dependabot/automerge.ts)_
 
 ## `sfdx dependabot:consolidate -m major|minor|patch -b <string> -t <string> [--ignore <array>] [-d] [--no-pr] [-r <string> -o <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -677,7 +677,7 @@ EXAMPLES
   $ sfdx dependabot:consolidate --max-version-bump major
 ```
 
-_See code: [src/commands/dependabot/consolidate.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/dependabot/consolidate.ts)_
+_See code: [src/commands/dependabot/consolidate.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/dependabot/consolidate.ts)_
 
 ## `sfdx npm:dependencies:pin [-d] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -703,7 +703,7 @@ DESCRIPTION
   in the package.json
 ```
 
-_See code: [src/commands/npm/dependencies/pin.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/npm/dependencies/pin.ts)_
+_See code: [src/commands/npm/dependencies/pin.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/npm/dependencies/pin.ts)_
 
 ## `sfdx npm:package:promote -c <string> [-d] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -731,16 +731,16 @@ EXAMPLES
   $ sfdx npm:package:promote --candidate latest-rc --target latest
 ```
 
-_See code: [src/commands/npm/package/promote.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/npm/package/promote.ts)_
+_See code: [src/commands/npm/package/promote.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/npm/package/promote.ts)_
 
-## `sfdx npm:package:release [-d] [-s] [-t <string>] [-a <string>] [--install] [--prerelease <string>] [--verify] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+## `sfdx npm:package:release [-d] [-s] [-t <string>] [-a <string>] [--install] [--prerelease <string>] [--verify] [--githubtag <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
 publish npm package
 
 ```
 USAGE
   $ sfdx npm:package:release [-d] [-s] [-t <string>] [-a <string>] [--install] [--prerelease <string>] [--verify]
-    [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
+    [--githubtag <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 FLAGS
   -a, --npmaccess=<value>                                                           [default: public] access level to
@@ -752,6 +752,11 @@ FLAGS
                                                                                     uploaded to S3
   -t, --npmtag=<value>                                                              [default: latest] tag to use when
                                                                                     publishing to npm
+  --githubtag=<value>                                                               given a github tag, release the
+                                                                                    version specified in the
+                                                                                    package.json as is. Useful when
+                                                                                    you've already done a release and
+                                                                                    only need npm publish features
   --[no-]install                                                                    run yarn install and build on
                                                                                     repository
   --json                                                                            format output as json
@@ -767,7 +772,7 @@ DESCRIPTION
   publish npm package
 ```
 
-_See code: [src/commands/npm/package/release.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/npm/package/release.ts)_
+_See code: [src/commands/npm/package/release.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/npm/package/release.ts)_
 
 ## `sfdx npm:release:validate [--verbose] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -789,7 +794,7 @@ DESCRIPTION
   inspects the git commits to see if there are any commits that will warrant a new release
 ```
 
-_See code: [src/commands/npm/release/validate.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/npm/release/validate.ts)_
+_See code: [src/commands/npm/release/validate.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/npm/release/validate.ts)_
 
 ## `sfdx plugins:trust:verify -n <string> [-r <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -860,7 +865,7 @@ EXAMPLES
   $ sfdx repositories --json | jq -r '.result[] | select(.name=="sfdx-core") | .packages[] | .url
 ```
 
-_See code: [src/commands/repositories/index.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/repositories/index.ts)_
+_See code: [src/commands/repositories/index.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/repositories/index.ts)_
 
 ## `sfdx typescript:update [-v <string>] [-t <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -887,6 +892,6 @@ DESCRIPTION
   Runs tests with updated typescript version and ES target
 ```
 
-_See code: [src/commands/typescript/update.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.0.1/src/commands/typescript/update.ts)_
+_See code: [src/commands/typescript/update.ts](https://github.com/salesforcecli/plugin-release-management/blob/v3.1.3-dev.0/src/commands/typescript/update.ts)_
 
 <!-- commandsstop -->

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -16,72 +16,86 @@
       "targets",
       "version",
       "xz"
-    ]
+    ],
+    "alias": []
   },
   {
     "command": "circleci",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["contains-package-type", "json", "loglevel"]
+    "flags": ["contains-package-type", "json", "loglevel"],
+    "alias": []
   },
   {
     "command": "circleci:envvar:create",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
+    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"],
+    "alias": []
   },
   {
     "command": "circleci:envvar:update",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"]
+    "flags": ["dryrun", "envvar", "json", "loglevel", "slug"],
+    "alias": []
   },
   {
     "command": "cli:install:test",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["channel", "cli", "json", "loglevel", "method", "output-file"]
+    "flags": ["channel", "cli", "json", "loglevel", "method", "output-file"],
+    "alias": []
   },
   {
     "command": "cli:latestrc:build",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["build-only", "json", "loglevel", "only", "patch", "pinned-deps", "rctag", "resolutions"]
+    "flags": ["build-only", "json", "loglevel", "only", "patch", "pinned-deps", "rctag", "resolutions"],
+    "alias": []
   },
   {
     "command": "cli:releasenotes",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["cli", "json", "loglevel", "markdown", "since"]
+    "flags": ["cli", "json", "loglevel", "markdown", "since"],
+    "alias": []
   },
   {
     "command": "cli:schemas:collect",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel"]
+    "flags": ["json", "loglevel"],
+    "alias": []
   },
   {
     "command": "cli:schemas:compare",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel"]
+    "flags": ["json", "loglevel"],
+    "alias": []
   },
   {
     "command": "cli:tarballs:prepare",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "types", "verbose"]
+    "flags": ["dryrun", "json", "loglevel", "types", "verbose"],
+    "alias": []
   },
   {
     "command": "cli:tarballs:smoke",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["cli", "json", "loglevel", "verbose"]
+    "flags": ["cli", "json", "loglevel", "verbose"],
+    "alias": []
   },
   {
     "command": "cli:tarballs:verify",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["cli", "json", "loglevel", "windows-username-buffer"]
+    "flags": ["cli", "json", "loglevel", "windows-username-buffer"],
+    "alias": []
   },
   {
     "command": "cli:versions:inspect",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["channels", "cli", "dependencies", "json", "locations", "loglevel", "salesforce"]
+    "flags": ["channels", "cli", "dependencies", "json", "locations", "loglevel", "salesforce"],
+    "alias": []
   },
   {
     "command": "dependabot:automerge",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "merge-method", "owner", "repo", "skip-ci"]
+    "flags": ["dryrun", "json", "loglevel", "max-version-bump", "merge-method", "owner", "repo", "skip-ci"],
+    "alias": []
   },
   {
     "command": "dependabot:consolidate",
@@ -97,41 +111,60 @@
       "owner",
       "repo",
       "target-branch"
-    ]
+    ],
+    "alias": []
   },
   {
     "command": "npm:dependencies:pin",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "json", "loglevel", "tag"]
+    "flags": ["dryrun", "json", "loglevel", "tag"],
+    "alias": []
   },
   {
     "command": "npm:package:promote",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["candidate", "dryrun", "json", "loglevel", "target"]
+    "flags": ["candidate", "dryrun", "json", "loglevel", "target"],
+    "alias": []
   },
   {
     "command": "npm:package:release",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["dryrun", "install", "json", "loglevel", "npmaccess", "npmtag", "prerelease", "sign", "verify"]
+    "flags": [
+      "dryrun",
+      "githubtag",
+      "install",
+      "json",
+      "loglevel",
+      "npmaccess",
+      "npmtag",
+      "prerelease",
+      "sign",
+      "verify"
+    ],
+    "alias": []
   },
   {
     "command": "npm:release:validate",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "verbose"]
+    "flags": ["json", "loglevel", "verbose"],
+    "alias": []
   },
   {
     "command": "plugins:trust:verify",
     "plugin": "@salesforce/plugin-trust",
-    "flags": ["json", "loglevel", "npm", "registry"]
+    "flags": ["json", "loglevel", "npm", "registry"],
+    "alias": []
   },
   {
     "command": "repositories",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"]
+    "flags": ["columns", "csv", "extended", "filter", "json", "loglevel", "no-header", "no-truncate", "output", "sort"],
+    "alias": []
   },
   {
     "command": "typescript:update",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json", "loglevel", "target", "version"]
+    "flags": ["json", "loglevel", "target", "version"],
+    "alias": []
   }
 ]

--- a/messages/npm.package.release.json
+++ b/messages/npm.package.release.json
@@ -5,6 +5,7 @@
   "npmTag": "tag to use when publishing to npm",
   "npmAccess": "access level to use when publishing to npm",
   "install": "run yarn install and build on repository",
+  "githubtag": "given a github tag, release the version specified in the package.json as is. Useful when you've already done a release and only need npm publish features",
   "prerelease": "determine the next version as <version>-<prerelease>.0 if version is not manually set",
   "verify": "verify npm registry has new version after publish and digital signature",
   "InvalidNextVersion": "%s already exists in the public npm registry",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-release-management",
   "description": "A plugin for preparing and publishing npm packages",
-  "version": "3.1.2-dev.0",
+  "version": "3.1.2",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@salesforce/command": "^5.2.3",
     "@salesforce/core": "^3.26.0",
     "@salesforce/kit": "^1.6.0",
+    "@salesforce/plugin-command-reference": "^1.4.0",
     "@salesforce/plugin-trust": "^2.0.3",
     "@salesforce/ts-types": "^1.5.20",
     "agent-base": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-release-management",
   "description": "A plugin for preparing and publishing npm packages",
-  "version": "3.1.2",
+  "version": "3.1.3-dev.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-release-management",
   "description": "A plugin for preparing and publishing npm packages",
-  "version": "3.1.3-dev.0",
+  "version": "3.1.3",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-release-management",
   "description": "A plugin for preparing and publishing npm packages",
-  "version": "3.0.2",
+  "version": "3.1.2-dev.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "bin": {
@@ -37,7 +37,6 @@
     "@oclif/plugin-command-snapshot": "^3",
     "@salesforce/dev-config": "^3.0.0",
     "@salesforce/dev-scripts": "^2.0.3",
-    "@salesforce/plugin-command-reference": "^1.4.0",
     "@salesforce/prettier-config": "^0.0.2",
     "@salesforce/ts-sinon": "1.3.21",
     "@types/conventional-changelog-preset-loader": "^2.3.1",

--- a/src/commands/npm/package/release.ts
+++ b/src/commands/npm/package/release.ts
@@ -80,7 +80,7 @@ export default class Release extends SfdxCommand {
 
     await pkg.writeNpmToken();
 
-    if (this.flags['github-tag']) {
+    if (this.flags.githubtag) {
       this.ux.log(`Using Version: ${pkg.nextVersion}`);
     } else {
       pkg.printStage('Validate Next Version');
@@ -102,7 +102,7 @@ export default class Release extends SfdxCommand {
       pkg.build();
     }
 
-    if (!this.flags['github-tag']) {
+    if (!this.flags.githubtag) {
       pkg.printStage('Prepare Release');
       pkg.prepare({ dryrun: this.flags.dryrun as boolean });
     }

--- a/src/commands/npm/package/release.ts
+++ b/src/commands/npm/package/release.ts
@@ -59,6 +59,9 @@ export default class Release extends SfdxCommand {
       default: true,
       allowNo: true,
     }),
+    githubtag: flags.string({
+      description: messages.getMessage('githubtag'),
+    }),
   };
 
   public async run(): Promise<ReleaseResult> {
@@ -77,15 +80,19 @@ export default class Release extends SfdxCommand {
 
     await pkg.writeNpmToken();
 
-    pkg.printStage('Validate Next Version');
-    const pkgValidation = pkg.validate();
-    if (!pkgValidation.valid) {
-      const errType = 'InvalidNextVersion';
-      throw new SfError(messages.getMessage(errType, [pkgValidation.nextVersion]), errType);
+    if (this.flags['github-tag']) {
+      this.ux.log(`Using Version: ${pkg.nextVersion}`);
+    } else {
+      pkg.printStage('Validate Next Version');
+      const pkgValidation = pkg.validate();
+      if (!pkgValidation.valid) {
+        const errType = 'InvalidNextVersion';
+        throw new SfError(messages.getMessage(errType, [pkgValidation.nextVersion]), errType);
+      }
+      this.ux.log(`Name: ${pkgValidation.name}`);
+      this.ux.log(`Current Version: ${pkgValidation.currentVersion}`);
+      this.ux.log(`Next Version: ${pkgValidation.nextVersion}`);
     }
-    this.ux.log(`Name: ${pkgValidation.name}`);
-    this.ux.log(`Current Version: ${pkgValidation.currentVersion}`);
-    this.ux.log(`Next Version: ${pkgValidation.nextVersion}`);
 
     if (this.flags.install) {
       pkg.printStage('Install');
@@ -95,9 +102,10 @@ export default class Release extends SfdxCommand {
       pkg.build();
     }
 
-    pkg.printStage('Prepare Release');
-    pkg.prepare({ dryrun: this.flags.dryrun as boolean });
-
+    if (!this.flags['github-tag']) {
+      pkg.printStage('Prepare Release');
+      pkg.prepare({ dryrun: this.flags.dryrun as boolean });
+    }
     let signature: SigningResponse;
     if (this.flags.sign && !this.flags.dryrun) {
       pkg.printStage('Sign and Upload Security Files');
@@ -130,7 +138,7 @@ export default class Release extends SfdxCommand {
         this.verifySign(pkg.getPkgInfo());
       }
     } finally {
-      if (!this.flags.dryrun) {
+      if (!this.flags.dryrun && !this.flags.githubtag) {
         pkg.printStage('Push Changes to Git');
         pkg.pushChangesToGit();
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,6 +852,40 @@
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
+"@oclif/core@^1.14.1", "@oclif/core@^1.6.4":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.16.0.tgz#4b53261eeb0c0244700bfc9eb41159d483436f21"
+  integrity sha512-xtqhAbjQHBcz+xQpEHJ3eJEVfRQ4zl41Yw5gw/N+D1jgaIUrHTxCY/sfTvhw93LAQo7B++ozHzSb7DISFXsQFQ==
+  dependencies:
+    "@oclif/linewrap" "^1.0.0"
+    "@oclif/screen" "^3.0.2"
+    ansi-escapes "^4.3.2"
+    ansi-styles "^4.3.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.10.0"
+    debug "^4.3.4"
+    ejs "^3.1.6"
+    fs-extra "^9.1.0"
+    get-package-type "^0.1.0"
+    globby "^11.1.0"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.14.1"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.33"
+    password-prompt "^1.1.2"
+    semver "^7.3.7"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    tslib "^2.3.1"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
 "@oclif/dev-cli@^1":
   version "1.26.10"
   resolved "https://registry.yarnpkg.com/@oclif/dev-cli/-/dev-cli-1.26.10.tgz#d8df3a79009b68552f5e7f249d1d19ca52278382"
@@ -981,6 +1015,14 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-3.0.2.tgz#969054308fe98d130c02844a45cc792199b75670"
   integrity sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==
+
+"@oclif/test@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@oclif/test/-/test-2.1.1.tgz#140ed05ece651cdf427306b5c878826e273a1722"
+  integrity sha512-vuBDXnXbnU073xNUqj+V4Fbrp+6Xhs1sgeWUIMj69SP9qC3pUBPfEPzIoK00ga6/WxZ+2qUgqCBAOPGz3nmTEg==
+  dependencies:
+    "@oclif/core" "^1.6.4"
+    fancy-test "^2.0.0"
 
 "@octokit/auth-token@^2.4.4":
   version "2.5.0"
@@ -1166,6 +1208,19 @@
     "@salesforce/ts-types" "^1.5.20"
     chalk "^2.4.2"
 
+"@salesforce/command@^5.1.3":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@salesforce/command/-/command-5.2.6.tgz#649e3c1ab2c4f5a71b1c908f95a644c1b398d7da"
+  integrity sha512-Rsvk8k4ZKwZiMD6STSTHMNPigqkr+hycuRwjm1pk57vDDSllVVa3R8yv0em1OoJsiyIH7l/zhRQ6IcZ7ObM7Jg==
+  dependencies:
+    "@oclif/core" "^1.14.1"
+    "@oclif/plugin-help" "^5.1.11"
+    "@oclif/test" "^2.1.0"
+    "@salesforce/core" "^3.26.2"
+    "@salesforce/kit" "^1.6.0"
+    "@salesforce/ts-types" "^1.5.20"
+    chalk "^2.4.2"
+
 "@salesforce/core@^3.10.1", "@salesforce/core@^3.20.1", "@salesforce/core@^3.26.0":
   version "3.26.0"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.26.0.tgz#8bbbdf22882c4245f4acc18dc077030743c1005b"
@@ -1186,6 +1241,29 @@
     graceful-fs "^4.2.9"
     js2xmlparser "^4.0.1"
     jsforce "^2.0.0-beta.16"
+    jsonwebtoken "8.5.1"
+    ts-retry-promise "^0.6.0"
+
+"@salesforce/core@^3.19.5", "@salesforce/core@^3.26.2":
+  version "3.26.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.26.2.tgz#94b361bd62967feb3eedc624fc6cf444e7347f84"
+  integrity sha512-GDrho8jbh1UDjcsYRRUzhNv4KUsMcBtux/yEqB2ycvHXhjVnrNkJcl99KESiU1eZMl2DGZEE1IO8yxnb2rSvgg==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.5.41"
+    "@salesforce/schemas" "^1.1.0"
+    "@salesforce/ts-types" "^1.5.20"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/semver" "^7.3.9"
+    ajv "^8.11.0"
+    archiver "^5.3.0"
+    change-case "^4.1.2"
+    debug "^3.2.7"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    graceful-fs "^4.2.9"
+    js2xmlparser "^4.0.1"
+    jsforce beta
     jsonwebtoken "8.5.1"
     ts-retry-promise "^0.6.0"
 
@@ -1242,6 +1320,18 @@
     "@salesforce/ts-types" "^1.5.20"
     shx "^0.3.3"
     tslib "^2.2.0"
+
+"@salesforce/plugin-command-reference@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/plugin-command-reference/-/plugin-command-reference-1.4.0.tgz#560f1d352895f5c4d30259ee1d55ccb2978cc85e"
+  integrity sha512-7m8J9o375lFqFYUkzgmsnIYNiIIjpOn56nYtmNv17JNKH3TktPmu0pu1QzCuXjFE6VA1w4Zo79IkyGelhove5w==
+  dependencies:
+    "@salesforce/command" "^5.1.3"
+    "@salesforce/core" "^3.19.5"
+    chalk "^3.0.0"
+    handlebars "4.7.7"
+    shelljs "^0.8.5"
+    tslib "^1"
 
 "@salesforce/plugin-trust@^2.0.3":
   version "2.0.3"
@@ -1412,6 +1502,11 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/chai@*":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
+  integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
+
 "@types/chai@^4.2.11":
   version "4.2.22"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.22.tgz#47020d7e4cf19194d43b5202f35f75bd2ad35ce7"
@@ -1511,6 +1606,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@*":
+  version "4.14.184"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.184.tgz#23f96cd2a21a28e106dc24d825d4aa966de7a9fe"
+  integrity sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -1570,6 +1670,13 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
+
+"@types/sinon@*":
+  version "10.0.13"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.13.tgz#60a7a87a70d9372d0b7b38cc03e825f46981fb83"
+  integrity sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
 
 "@types/sinon@10.0.11":
   version "10.0.11"
@@ -3750,6 +3857,20 @@ extract-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/extract-stack/-/extract-stack-2.0.0.tgz#11367bc865bfcd9bc0db3123e5edb57786f11f9b"
   integrity sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==
 
+fancy-test@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fancy-test/-/fancy-test-2.0.0.tgz#f1477ae4190820318816914aabe273c0a0dbd597"
+  integrity sha512-SFb2D/VX9SV+wNYXO1IIh1wyxUC1GS0mYCFJOWD1ia7MPj9yE2G8jaPkw4t/pg0Sj7/YJP56OzMY4nAuJSOugQ==
+  dependencies:
+    "@types/chai" "*"
+    "@types/lodash" "*"
+    "@types/node" "*"
+    "@types/sinon" "*"
+    lodash "^4.17.13"
+    mock-stdin "^1.0.0"
+    nock "^13.0.0"
+    stdout-stderr "^0.1.9"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -4405,7 +4526,7 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-handlebars@^4.7.6:
+handlebars@4.7.7, handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -5231,6 +5352,32 @@ jsforce@^2.0.0-beta.16:
     strip-ansi "^6.0.0"
     xml2js "^0.4.22"
 
+jsforce@beta:
+  version "2.0.0-beta.18"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.18.tgz#2791a2e6ec15d4d8b41f0782e23b833f5dbe5678"
+  integrity sha512-9IKv3M/U/FCdL6G8WlFqWiBTvLx1TRmGW+JhcSWHZb0YlMLHiGNVymvLyPsvRfO9sNP6VR3A5AIntqD+UsDKkQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@babel/runtime-corejs3" "^7.12.5"
+    "@types/node" "^12.19.9"
+    abort-controller "^3.0.0"
+    base64url "^3.0.1"
+    commander "^4.0.1"
+    core-js "^3.6.4"
+    csv-parse "^4.8.2"
+    csv-stringify "^5.3.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    fs-extra "^8.1.0"
+    https-proxy-agent "^5.0.0"
+    inquirer "^7.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    open "^7.0.0"
+    regenerator-runtime "^0.13.3"
+    strip-ansi "^6.0.0"
+    xml2js "^0.4.22"
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -5660,7 +5807,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6076,6 +6223,11 @@ mocha@^9.1.3:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+mock-stdin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-1.0.0.tgz#efcfaf4b18077e14541742fd758b9cae4e5365ea"
+  integrity sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
@@ -6235,6 +6387,16 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+nock@^13.0.0:
+  version "13.2.9"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.9.tgz#4faf6c28175d36044da4cfa68e33e5a15086ad4c"
+  integrity sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+    propagate "^2.0.0"
 
 node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
@@ -7227,6 +7389,11 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
+
 proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-5.0.0.tgz#d31405c10d6e8431fde96cba7a0c027ce01d633b"
@@ -8055,6 +8222,14 @@ standard-version@^9.0.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+stdout-stderr@^0.1.9:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/stdout-stderr/-/stdout-stderr-0.1.13.tgz#54e3450f3d4c54086a49c0c7f8786a44d1844b6f"
+  integrity sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==
+  dependencies:
+    debug "^4.1.1"
+    strip-ansi "^6.0.0"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -8478,7 +8653,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,7 +1154,7 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/command@^5.0.4", "@salesforce/command@^5.1.3", "@salesforce/command@^5.2.3":
+"@salesforce/command@^5.0.4", "@salesforce/command@^5.2.3":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@salesforce/command/-/command-5.2.3.tgz#1bb32ddea1ed95758ac14c48358f50718a3adbe1"
   integrity sha512-nDWlNEiE/XPuQrkLHw9f57p5zeAzWQLJ4olrUVRziJaPdhrt4KpqO8GsB1sF2I46P/2Q0nrl/l4xY/5ZzKzLUA==
@@ -1166,7 +1166,7 @@
     "@salesforce/ts-types" "^1.5.20"
     chalk "^2.4.2"
 
-"@salesforce/core@^3.10.1", "@salesforce/core@^3.19.5", "@salesforce/core@^3.20.1", "@salesforce/core@^3.26.0":
+"@salesforce/core@^3.10.1", "@salesforce/core@^3.20.1", "@salesforce/core@^3.26.0":
   version "3.26.0"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.26.0.tgz#8bbbdf22882c4245f4acc18dc077030743c1005b"
   integrity sha512-Ki1c4trNaUA+zvPe29ocaccNPN3mjesq5R/IJYOS/v+IvcjI9Iuf/9ECOE5pgZiLlbUsK0ZqBXu7hYMKiHgTSQ==
@@ -1242,18 +1242,6 @@
     "@salesforce/ts-types" "^1.5.20"
     shx "^0.3.3"
     tslib "^2.2.0"
-
-"@salesforce/plugin-command-reference@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/plugin-command-reference/-/plugin-command-reference-1.4.0.tgz#560f1d352895f5c4d30259ee1d55ccb2978cc85e"
-  integrity sha512-7m8J9o375lFqFYUkzgmsnIYNiIIjpOn56nYtmNv17JNKH3TktPmu0pu1QzCuXjFE6VA1w4Zo79IkyGelhove5w==
-  dependencies:
-    "@salesforce/command" "^5.1.3"
-    "@salesforce/core" "^3.19.5"
-    chalk "^3.0.0"
-    handlebars "4.7.7"
-    shelljs "^0.8.5"
-    tslib "^1"
 
 "@salesforce/plugin-trust@^2.0.3":
   version "2.0.3"
@@ -4417,7 +4405,7 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-handlebars@4.7.7, handlebars@^4.7.6:
+handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -8490,7 +8478,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
### What does this PR do?
add a new flag for the package release command.  
use case: you've published a github tagged release and want to npm publish (and optionally sign) exactly that.

It skips standard version, tagging, changelog, and pushing anything to git

### What issues does this PR fix or reference?
[@W-11585002@](https://gus.lightning.force.com/a07EE000013uWrdYAE)

available for testing as `"version": "3.1.2-dev.0",`

QA for publish/sign
https://github.com/salesforcecli/testPackageRelease/runs/8020893079?check_suite_focus=true