### PR TITLE
Sm/schema snapshot on rc

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -46,7 +46,18 @@
   {
     "command": "cli:latestrc:build",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["build-only", "json", "loglevel", "only", "patch", "pinned-deps", "rctag", "resolutions"],
+    "flags": [
+      "build-only",
+      "json",
+      "loglevel",
+      "only",
+      "patch",
+      "pinned-deps",
+      "rctag",
+      "resolutions",
+      "schema",
+      "snapshot"
+    ],
     "alias": []
   },
   {

--- a/messages/cli.latestrc.build.json
+++ b/messages/cli.latestrc.build.json
@@ -12,6 +12,8 @@
     "pinnedDeps": "bump the versions of the packages listed in the pinnedDependencies section",
     "only": "only bump the version of the packages passed in, uses latest if version is not provided",
     "patch": "bump the release as a patch of an existing version, not a new minor version",
-    "buildOnly": "only build the latest rc, do not git add/commit/push"
+    "buildOnly": "only build the latest rc, do not git add/commit/push",
+    "snapshot": "update the snapshots and commit them to the PR",
+    "schema": "update the schemas and commit them to the PR"
   }
 }

--- a/src/commands/cli/latestrc/build.ts
+++ b/src/commands/cli/latestrc/build.ts
@@ -46,6 +46,12 @@ export default class build extends SfdxCommand {
     patch: flags.boolean({
       description: messages.getMessage('flags.patch'),
     }),
+    snapshot: flags.boolean({
+      description: messages.getMessage('flags.snapshot'),
+    }),
+    schema: flags.boolean({
+      description: messages.getMessage('flags.schema'),
+    }),
   };
 
   public async run(): Promise<void> {
@@ -107,7 +113,16 @@ export default class build extends SfdxCommand {
     this.exec('yarn install');
     // streamline the lockfile
     this.exec('npx yarn-deduplicate');
-    this.exec('yarn snapshot-generate');
+
+    if (this.flags.snapshot) {
+      this.ux.log('updating snapshots');
+      this.exec('./bin/run snapshot:generate', { silent: false });
+    }
+
+    if (this.flags.schema) {
+      this.ux.log('updating schema');
+      this.exec('./bin/run cli:schemas:collect', { silent: false });
+    }
 
     if (pushChangesToGitHub) {
       const octokit = new Octokit({ auth });


### PR DESCRIPTION
### What does this PR do?
add 2 flags to the cli:latestrc:build command.  When true, the command will generate snapshots and collect schemas.
This will reduce manual work for sf releases

removes `silent` from these two exec cmds, too (they were failing silently) so we get logs in CI

### What issues does this PR fix or reference?
[@W-11585071@](https://gus.lightning.force.com/a07EE000013ualCYAQ)