### PR TITLE
feat: allow skipped checks automerge

### DIFF
--- a/src/commands/dependabot/automerge.ts
+++ b/src/commands/dependabot/automerge.ts
@@ -150,7 +150,11 @@ export default class AutoMerge extends SfdxCommand {
     });
     this.ux.logJson(checkRunResponse.data);
 
-    if (checkRunResponse.data.check_runs.every((cr) => cr.status === 'completed' && cr.conclusion === 'success')) {
+    if (
+      checkRunResponse.data.check_runs.every(
+        (cr) => cr.status === 'completed' && ['success', 'skipped'].includes(cr.conclusion)
+      )
+    ) {
       return pr;
     }
   }


### PR DESCRIPTION
### What does this PR do?
repos with skippable checks (ex: [sandbox nuts](https://github.com/salesforcecli/plugin-org/actions/runs/3105185768/jobs/5030500396)) aren't automerging because my previous code insisted all checks be complete and successful. 

This allows skipped checks in the "is it passing" decision

### What issues does this PR fix or reference?
@W-11584724@