### PR TITLE
Don't delete remote branch if build-only

### DIFF
--- a/src/commands/cli/release/build.ts
+++ b/src/commands/cli/release/build.ts
@@ -108,8 +108,7 @@ export default class build extends SfCommand<void> {
     // Ensure branch does not already exist on the remote (origin)
     // We only look at remote branches since they are likely generated
     // We do not want to delete a locally built `cli:release:build` branch
-    const remoteBranchExists = await this.exec(`git ls-remote --heads origin ${branchName}`);
-    if (remoteBranchExists) {
+    if (pushChangesToGitHub && (await this.exec(`git ls-remote --heads origin ${branchName}`))) {
       await this.exec(`git push origin --delete ${branchName}`);
     }
 


### PR DESCRIPTION
### What does this PR do?
Will not delete remote branch if you are running this command with `--build-only`

### What issues does this PR fix or reference?
[@W-12376135@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12376135)