### PR TITLE
Dedup before scripts

### DIFF
--- a/src/commands/cli/release/build.ts
+++ b/src/commands/cli/release/build.ts
@@ -156,9 +156,12 @@ export default class build extends SfCommand<void> {
     }
     repo.package.writePackageJson();
 
-    await this.exec('yarn install');
-    // streamline the lockfile
+    // Run an install to generate the lock file (skip all pre/post scripts)
+    await this.exec('yarn install --ignore-scripts');
+    // Remove duplicates in the lockfile
     await this.exec('npx yarn-deduplicate');
+    // Run an install with deduplicated dependencies (with scripts)
+    await this.exec('yarn install');
 
     if (flags.snapshot) {
       this.log('Updating snapshots');


### PR DESCRIPTION
### What does this PR do?
We often have Type conflicts in our Release builds because of slightly different versions of libraries. Usually running `npx yarn-deduplicate` will fix these issues by getting all plugins using the same library versions (as long as it satisfies semver)

The problem is, `sf-compile` will run as a post-install script. It often throws Type errors and stops our Release builds since it runs before we have a chance to deduplicate dependencies. 

With this change the flow will be:
- Run **just** an install first with `--ignore-scripts` 
- Run `npx yarn-deduplicate` to remove deps
- Run another [standard] install to install deduped deps and run all pre/post install scripts

### What issues does this PR fix or reference?
[skip-validate-pr]