### PR TITLE
Ensure Platform CLI git2gus configuration

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,4 +1,9 @@
 {
-    "productTag": "a1aB00000004Bx8IAE",
-    "defaultBuild": "offcore.tooling.52"
+  "productTag": "a1aB00000004Bx8IAE",
+  "defaultBuild": "offcore.tooling.56",
+  "issueTypeLabels": {
+    "feature": "USER STORY",
+    "regression": "BUG P1",
+    "bug": "BUG P3"
+  }
 }


### PR DESCRIPTION
The Platform CLI gi2gus configuration ensures Pull Requests labeled with the following become GUS work items for the Platform CLI team. Those are then triaged and distributed accordingly within GUS.

Mapping:

* feature ➡️ User Story
* regression ➡️ Bug P1
* bug ➡️ Bug P3

[@W-11989115@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001BDciaYAD/view)

[no ci]
