### PR TITLE
fix: don't swallow `execSync` error

### DIFF
--- a/src/commands/cli/tarballs/smoke.ts
+++ b/src/commands/cli/tarballs/smoke.ts
@@ -92,7 +92,8 @@ export default class SmokeTest extends SfCommand<void> {
       }
       return stdout;
     } catch (e) {
-      throw new SfError(`Failed: ${command}`);
+      const err = e as Error;
+      throw new SfError(`Failed: ${command}.\n ${err.message}`);
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Makes wrapper around `execSync` print the error message of the spawned process when it fails.

### What issues does this PR fix or reference?
[skip-validate-pr]