### PR TITLE
Always log stdout

### DIFF
--- a/src/commands/cli/release/build.ts
+++ b/src/commands/cli/release/build.ts
@@ -6,7 +6,7 @@
  */
 
 import { promisify } from 'node:util';
-import { exec as execSync } from 'child_process';
+import { exec as execSync, ExecException } from 'child_process';
 import { arrayWithDeprecation, Flags, SfCommand, Ux } from '@salesforce/sf-plugins-core';
 import { ensureString } from '@salesforce/ts-types';
 import { Env } from '@salesforce/kit';
@@ -222,12 +222,22 @@ export default class build extends SfCommand<void> {
   private async exec(command: string, silent = false): Promise<string> {
     try {
       const { stdout } = await exec(command);
+
       if (!silent) {
         this.styledHeader(command);
         this.log(stdout);
       }
+
       return stdout;
     } catch (err) {
+      // An error will throw before `stdout` is able to be log above. The child_process.exec adds stdout and stderr to the error object
+      const error = err as ExecException & {
+        stdout: string;
+        stderr: string;
+      };
+
+      this.log(error.stdout);
+
       throw new SfError((err as Error).message);
     }
   }


### PR DESCRIPTION
### What does this PR do?
Some output was getting lost in the `cli:release:build` script when errors were thrown. Some error details exist on `stdout` instead of the `error.message`. When `child_process.exec` is promisified, the `stdout` and `stderr` are added to the err object ([highlight link to docs](https://nodejs.org/api/child_process.html#:~:text=execute%20the%20command.-,If%20this%20method%20is%20invoked%20as%20its%20util.promisify()ed,the%20callback%2C%20but%20with%20two%20additional%20properties%20stdout%20and%20stderr.,-const%20util%20%3D)). We can log the additional error detail from `error.stdout` to get better output in Github Actions

### Example
Before: https://github.com/salesforcecli/sfdx-cli/actions/runs/4050136185/jobs/6967228421#step:12:55
After:
<img width="1503" alt="Screenshot 2023-01-31 at 1 50 05 PM" src="https://user-images.githubusercontent.com/1715111/215871106-a779c04b-82f8-4be6-9aba-db573f9d6705.png">

### What issues does this PR fix or reference?
[@W-12467974@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12467974)