### PR TITLE
feat: ensure plugin versions are pinned before comparing artifacts

### DIFF
--- a/messages/cli.artifacts.compare.json
+++ b/messages/cli.artifacts.compare.json
@@ -7,5 +7,6 @@
   "flags.current.summary": "Current CLI version to compare against. Defaults to the version on the CLI in the current directory.",
   "error.VersionNotFound": "Version not found: %s.",
   "error.InvalidVersions": "Current version %s must be newer than previous version %s.",
-  "error.InvalidRepo": "This command must be run from the root directory of @salesforce/cli or sfdx-cli."
+  "error.InvalidRepo": "This command must be run from the root directory of @salesforce/cli or sfdx-cli.",
+  "error.VersionNotPinned": "Plugin %s is not pinned in package.json."
 }

--- a/src/commands/cli/release/build.ts
+++ b/src/commands/cli/release/build.ts
@@ -69,9 +69,11 @@ export default class build extends SfCommand<void> {
     }),
     snapshot: Flags.boolean({
       summary: messages.getMessage('flags.snapshot'),
+      deprecated: true,
     }),
     schema: Flags.boolean({
       summary: messages.getMessage('flags.schema'),
+      deprecated: true,
     }),
   };
 
@@ -174,13 +176,11 @@ export default class build extends SfCommand<void> {
     await this.exec('yarn install');
 
     if (flags.snapshot) {
-      this.log('Updating snapshots');
-      await this.exec(`./bin/${repo.name === 'sfdx-cli' ? 'dev.sh' : 'dev'} snapshot:generate`);
+      this.warn('snapshot flag is deprecated. Skipping snapshot updates.');
     }
 
     if (flags.schema) {
-      this.log('Updating schema');
-      await this.exec('sf-release cli:schemas:collect');
+      this.warn('schema flag is deprecated. Skipping schema updates.');
     }
 
     this.log('Updates complete');

--- a/src/commands/cli/schemas/collect.ts
+++ b/src/commands/cli/schemas/collect.ts
@@ -57,6 +57,8 @@ export default class Collect extends SfCommand<void> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly flags = {};
 
+  public static readonly state = 'deprecated';
+
   // eslint-disable-next-line class-methods-use-this
   public async run(): Promise<void> {
     const schemaFiles = await getLatestSchemaFiles();

--- a/src/commands/cli/schemas/compare.ts
+++ b/src/commands/cli/schemas/compare.ts
@@ -30,6 +30,7 @@ export default class Compare extends SfCommand<Results> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly flags = {};
+  public static readonly state = 'deprecated';
 
   public async run(): Promise<Results> {
     // The "existing schema" is the schema that is stored at the CLI level


### PR DESCRIPTION
### What does this PR do?

- Ensures that plugins are pinned before doing artifacts comparison
- Deprecates `cli:schemas:collect` and `cli:schemas:compare`
- Deprecates `schema` and `snapshot` flags on `cli:release:build`

### What issues does this PR fix or reference?
[skip-validate-pr]