### PR TITLE
fix: use correct path for verifying install

### DIFF
--- a/src/commands/cli/releasenotes.ts
+++ b/src/commands/cli/releasenotes.ts
@@ -132,7 +132,7 @@ export default class ReleaseNotes extends SfCommand<ChangesByPlugin> {
     if (this.usernames[username]) return this.usernames[username];
 
     const { data } = await this.octokit.request('GET /users/{username}', { username });
-    const name = data.name ?? data.login ?? username;
+    const name = (data.name ?? data.login ?? username) as string;
     this.usernames[username] = name;
     return name;
   }

--- a/src/commands/cli/releasenotes.ts
+++ b/src/commands/cli/releasenotes.ts
@@ -132,7 +132,7 @@ export default class ReleaseNotes extends SfCommand<ChangesByPlugin> {
     if (this.usernames[username]) return this.usernames[username];
 
     const { data } = await this.octokit.request('GET /users/{username}', { username });
-    const name = (data.name ?? data.login ?? username) as string;
+    const name = data.name ?? data.login ?? username;
     this.usernames[username] = name;
     return name;
   }

--- a/src/commands/cli/tarballs/smoke.ts
+++ b/src/commands/cli/tarballs/smoke.ts
@@ -115,7 +115,7 @@ export default class SmokeTest extends SfCommand<void> {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         this.log(err.stderr);
       } finally {
-        const result = await this.verifyInstall(plugin, true);
+        const result = await this.verifyInstall(plugin, executable, true);
         if (result) {
           this.log(`✅ ${chalk.green(`Verified installation of ${plugin}\n`)}`);
         } else {
@@ -132,12 +132,12 @@ export default class SmokeTest extends SfCommand<void> {
 
   private async testInstall(executable: string, plugin: string, tag?: string): Promise<void> {
     await this.execute(executable, `plugins:install ${plugin}${tag ? `@${tag}` : ''}`);
-    await this.verifyInstall(plugin);
+    await this.verifyInstall(plugin, executable);
   }
 
-  private async verifyInstall(plugin: string, silent = false): Promise<boolean> {
+  private async verifyInstall(plugin: string, executable: string, silent = false): Promise<boolean> {
     const fileData = await fs.promises.readFile(
-      path.join(os.homedir(), '.local', 'share', this.flags.cli, 'package.json'),
+      path.join(os.homedir(), '.local', 'share', path.basename(executable), 'package.json'),
       'utf-8'
     );
     const packageJson = parseJson(fileData) as PackageJson;


### PR DESCRIPTION
### What does this PR do?

Ensure that the correct package.json path is used for verifying plugin install

### What issues does this PR fix or reference?
[skip-validate-pr]