### PR TITLE
fix: adds nightly channel, adds arm64 tars

### DIFF
--- a/src/commands/cli/versions/inspect.ts
+++ b/src/commands/cli/versions/inspect.ts
@@ -55,6 +55,7 @@ export enum Channel {
   STABLE_RC = 'stable-rc',
   LATEST = 'latest',
   LATEST_RC = 'latest-rc',
+  NIGHTLY = 'nightly',
 }
 
 export enum Location {
@@ -62,7 +63,7 @@ export enum Location {
   NPM = 'npm',
 }
 
-type ArchiveChannel = Extract<Channel, Channel.STABLE | Channel.STABLE_RC | Channel.LEGACY>;
+type ArchiveChannel = Extract<Channel, Channel.STABLE | Channel.STABLE_RC | Channel.NIGHTLY | Channel.LEGACY>;
 type Archives = Record<ArchiveChannel, string[]>;
 type ChannelMapping = Record<Location, Record<Channel, Channel>>;
 
@@ -70,6 +71,8 @@ const ARCHIVES: Archives = {
   [Channel.STABLE]: [
     '%s/%s-darwin-x64.tar.gz',
     '%s/%s-darwin-x64.tar.xz',
+    '%s/%s-darwin-arm64.tar.gz',
+    '%s/%s-darwin-arm64.tar.xz',
     '%s/%s-linux-arm.tar.gz',
     '%s/%s-linux-arm.tar.xz',
     '%s/%s-linux-x64.tar.gz',
@@ -82,6 +85,22 @@ const ARCHIVES: Archives = {
   [Channel.STABLE_RC]: [
     '%s/%s-darwin-x64.tar.gz',
     '%s/%s-darwin-x64.tar.xz',
+    '%s/%s-darwin-arm64.tar.gz',
+    '%s/%s-darwin-arm64.tar.xz',
+    '%s/%s-linux-arm.tar.gz',
+    '%s/%s-linux-arm.tar.xz',
+    '%s/%s-linux-x64.tar.gz',
+    '%s/%s-linux-x64.tar.xz',
+    '%s/%s-win32-x64.tar.gz',
+    '%s/%s-win32-x64.tar.xz',
+    '%s/%s-win32-x86.tar.gz',
+    '%s/%s-win32-x86.tar.xz',
+  ],
+  [Channel.NIGHTLY]: [
+    '%s/%s-darwin-x64.tar.gz',
+    '%s/%s-darwin-x64.tar.xz',
+    '%s/%s-darwin-arm64.tar.gz',
+    '%s/%s-darwin-arm64.tar.xz',
     '%s/%s-linux-arm.tar.gz',
     '%s/%s-linux-arm.tar.xz',
     '%s/%s-linux-x64.tar.gz',
@@ -112,6 +131,7 @@ const CHANNEL_MAPPING: ChannelMapping = {
     [Channel.STABLE_RC]: Channel.LATEST_RC,
     [Channel.STABLE]: Channel.LATEST,
     [Channel.LATEST_RC]: Channel.LATEST_RC,
+    [Channel.NIGHTLY]: Channel.NIGHTLY,
     [Channel.LATEST]: Channel.LATEST,
     [Channel.LEGACY]: Channel.LEGACY,
   },
@@ -119,6 +139,7 @@ const CHANNEL_MAPPING: ChannelMapping = {
     [Channel.LATEST_RC]: Channel.STABLE_RC,
     [Channel.LATEST]: Channel.STABLE,
     [Channel.STABLE_RC]: Channel.STABLE_RC,
+    [Channel.NIGHTLY]: Channel.NIGHTLY,
     [Channel.STABLE]: Channel.STABLE,
     [Channel.LEGACY]: Channel.LEGACY,
   },
@@ -218,6 +239,7 @@ export default class Inspect extends SfCommand<Info[]> {
     const cli = ensure<CLI>(this.flags.cli);
     const stablePath = `https://developer.salesforce.com/media/salesforce-cli/${cli}/channels/stable`;
     const stableRcPath = `https://developer.salesforce.com/media/salesforce-cli/${cli}/channels/stable-rc`;
+    const nightlyPath = `https://developer.salesforce.com/media/salesforce-cli/${cli}/channels/nightly`;
     this.archives = {} as Archives;
     for (const [channel, paths] of Object.entries(ARCHIVES)) {
       if (channel === Channel.LEGACY && cli === CLI.SFDX) {
@@ -232,6 +254,8 @@ export default class Inspect extends SfCommand<Info[]> {
         this.archives[channel] = paths.map((p) => util.format(p, stablePath, this.flags.cli));
       } else if (channel === Channel.STABLE_RC) {
         this.archives[channel] = paths.map((p) => util.format(p, stableRcPath, this.flags.cli));
+      } else if (channel === Channel.NIGHTLY) {
+        this.archives[channel] = paths.map((p) => util.format(p, nightlyPath, this.flags.cli));
       }
     }
   }
@@ -253,8 +277,7 @@ export default class Inspect extends SfCommand<Info[]> {
         const curlResult = exec(`curl ${archivePath} -Os`, { cwd: tarDir });
         this.spinner.stop();
         if (curlResult.code !== 0) {
-          this.log(red('Download failed. That is a big deal. Investigate immediately.'));
-          continue;
+          throw new SfError(`Failed to download tar from ${archivePath}. Investigate immediately.`);
         }
         const filename = path.basename(archivePath);
         const unpackedDir = await mkdir(this.workingDir, 'unpacked', filename);
@@ -262,8 +285,7 @@ export default class Inspect extends SfCommand<Info[]> {
         const tarResult = exec(`tar -xf ${filename} -C ${unpackedDir} --strip-components 1`, { cwd: tarDir });
         this.spinner.stop();
         if (tarResult.code !== 0) {
-          this.log(red('Failed to unpack. Skipping...'));
-          continue;
+          throw new SfError(`Failed to unpack ${filename}. Stopping.`);
         }
         const pkgJson = await readPackageJson(unpackedDir);
         results.push({

--- a/src/commands/cli/versions/inspect.ts
+++ b/src/commands/cli/versions/inspect.ts
@@ -277,7 +277,8 @@ export default class Inspect extends SfCommand<Info[]> {
         const curlResult = exec(`curl ${archivePath} -Os`, { cwd: tarDir });
         this.spinner.stop();
         if (curlResult.code !== 0) {
-          throw new SfError(`Failed to download tar from ${archivePath}. Investigate immediately.`);
+          this.log(red('Download failed. That is a big deal. Investigate immediately.'));
+          continue;
         }
         const filename = path.basename(archivePath);
         const unpackedDir = await mkdir(this.workingDir, 'unpacked', filename);
@@ -285,7 +286,8 @@ export default class Inspect extends SfCommand<Info[]> {
         const tarResult = exec(`tar -xf ${filename} -C ${unpackedDir} --strip-components 1`, { cwd: tarDir });
         this.spinner.stop();
         if (tarResult.code !== 0) {
-          throw new SfError(`Failed to unpack ${filename}. Stopping.`);
+          this.log(red('Failed to unpack. Skipping...'));
+          continue;
         }
         const pkgJson = await readPackageJson(unpackedDir);
         results.push({


### PR DESCRIPTION
### What does this PR do?
- Adds support for the `nightly` channel on `cli:versions:inspect`
- Adds the Apple silicon (`arm64`) tarballs to the list for validation ([our docs](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm#sfdx_setup_install_cli_linux))
- ~~Changes a few logs to errors. The command will throw after logging the results, may as well fail early~~


### What issues does this PR fix or reference?
[@W-12632139@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12632139)