### PR TITLE
Correctly find the closest previous version

### DIFF
--- a/src/commands/cli/artifacts/compare.ts
+++ b/src/commands/cli/artifacts/compare.ts
@@ -455,7 +455,7 @@ export default class ArtifactsTest extends SfCommand<ArtifactsCompareResult> {
 
   private resolveVersions(): void {
     this.current = this.flags.current || this.packageJson.version;
-    this.previous = this.flags.previous ?? this.versions[this.versions.indexOf(this.current) + 1];
+    this.previous = this.flags.previous ?? this.versions.find((version) => semver.lt(version, this.current));
     this.log('Current Version:', this.current);
     this.log('Previous Version:', this.previous);
     if (this.flags.current && !this.versions.includes(this.flags.current)) {
@@ -590,7 +590,6 @@ export default class ArtifactsTest extends SfCommand<ArtifactsCompareResult> {
       this.warn(`No command-snapshot.json found for ${owner}/${repo}@${ref}`);
       return [];
     }
-
   }
 
   private async getTags(owner: string, repo: string): Promise<string[]> {


### PR DESCRIPTION
### What does this PR do?
The `sf` v2 beta revealed a bug in the `cli:artifact:compare` logic. Updated the version lookup to find the closest "less-than" semver version.

Failing build:
https://github.com/salesforcecli/cli/actions/runs/4792981346/jobs/8525014876?pr=709#step:6:10

QA:
<img width="972" alt="Screenshot 2023-04-25 at 4 07 02 PM" src="https://user-images.githubusercontent.com/1715111/234405617-7f691705-4cc3-47cc-b430-69ad72671b9b.png">


### What issues does this PR fix or reference?
[skip-validate-pr]