### PR TITLE
Add a 'pr-base-branch' flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -48,6 +48,7 @@
       "only",
       "patch",
       "pinned-deps",
+      "pr-base-branch",
       "release-channel",
       "resolutions",
       "start-from-github-ref",

--- a/messages/cli.release.build.json
+++ b/messages/cli.release.build.json
@@ -22,6 +22,7 @@
     "only": "only bump the version of the packages passed in, uses latest if version is not provided",
     "patch": "bump the release as a patch of an existing version, not a new minor version",
     "buildOnly": "only build the release, do not git add/commit/push",
-    "empty": "create an empty release PR for pushing changes to later (version will still be bumped)"
+    "empty": "create an empty release PR for pushing changes to later (version will still be bumped)",
+    "prBaseBranch": "the base branch to create the PR against, if not passed it will be determined for you"
   }
 }

--- a/messages/cli.release.build.json
+++ b/messages/cli.release.build.json
@@ -23,6 +23,6 @@
     "patch": "bump the release as a patch of an existing version, not a new minor version",
     "buildOnly": "only build the release, do not git add/commit/push",
     "empty": "create an empty release PR for pushing changes to later (version will still be bumped)",
-    "prBaseBranch": "the base branch to create the PR against, if not passed it will be determined for you"
+    "prBaseBranch": "base branch to create the PR against; if not specified, the build determines the branch for you"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Allows us to set the base branch for generated PRs. This will not be used often, but is handy for certain situations such as long running "nightlies" on prerelease branches. 

### What issues does this PR fix or reference?
[@W-13120638@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13120638)