### PR TITLE
fix: prevent lock refresh

### DIFF
--- a/src/jit.ts
+++ b/src/jit.ts
@@ -127,6 +127,11 @@ export async function testJITInstall(options: Options): Promise<void> {
         ux.log(`❌ ${chalk.red(`Failed installation of ${plugin}\n`)}`);
         failedInstalls.push(plugin);
       }
+      // Move the data dir so that we can start with a clean slate for the next plugin
+      // Deleting the dir would waste time, especially on Windows
+      // These prevents the 'oclif.lock' install refresh from slowing down the test
+      // There are integration tests in '@oclif/plugin-plugins' that test the oclif.lock refresh
+      await fs.promises.rename(dataDir, path.join(tmpDir, `data-${plugin.replace('@salesforce/', '')}`));
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
Prevents the oclif.lock refresh from happening. 
We have integration tests for that in `@oclif/plugin-plugins` [here](https://github.com/oclif/plugin-plugins/blob/main/test/integration/sf.integration.ts)

Testing this locally it went from 10m31s to 6m8s. 
This should make a significant difference on windows which currently take between 30-35 minutes ([example](https://github.com/salesforcecli/cli/actions/runs/6227941306/job/16903919583))

### What issues does this PR fix or reference?
[@W-14122700@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14122700)