### PR TITLE
Adds jit-plugin flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -31,9 +31,9 @@
   {
     "command": "cli:install:jit:test",
     "plugin": "@salesforce/plugin-release-management",
-    "flags": ["json"],
+    "flags": ["jit-plugin", "json"],
     "alias": [],
-    "flagChars": [],
+    "flagChars": ["j"],
     "flagAliases": []
   },
   {

--- a/messages/cli.install.jit.test.md
+++ b/messages/cli.install.jit.test.md
@@ -5,3 +5,7 @@ Test that all JIT plugins can be successfully installed.
 # examples
 
 - <%= config.bin %> <%= command.id %>
+
+# flags.jit-plugin.summary
+
+JIT plugin(s) to test, example: @salesforce/plugin-community

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-release-management",
   "description": "A plugin for preparing and publishing npm packages",
-  "version": "4.3.0",
+  "version": "4.3.1-dev.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "bin": {

--- a/src/commands/cli/install/jit/test.ts
+++ b/src/commands/cli/install/jit/test.ts
@@ -6,7 +6,7 @@
  */
 
 import { join } from 'path';
-import { SfCommand } from '@salesforce/sf-plugins-core';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
 import { testJITInstall } from '../../../../jit';
 
@@ -16,10 +16,19 @@ const messages = Messages.loadMessages('@salesforce/plugin-release-management', 
 export default class Test extends SfCommand<void> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
+  public static readonly flags = {
+    'jit-plugin': Flags.string({
+      summary: messages.getMessage('flags.jit-plugin.summary'),
+      char: 'j',
+      multiple: true,
+    }),
+  };
 
   public async run(): Promise<void> {
+    const { flags } = await this.parse(Test);
     await testJITInstall({
       jsonEnabled: this.jsonEnabled(),
+      jitPlugin: flags['jit-plugin'],
       executable: process.platform === 'win32' ? join('bin', 'run.cmd') : join('bin', 'run'),
     });
   }

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -22,12 +22,13 @@ const exec = promisify(execSync);
 
 type Options = {
   jsonEnabled: boolean;
+  jitPlugin?: string[] | undefined;
   executable: string;
   manifestPath?: string;
 };
 
 export async function testJITInstall(options: Options): Promise<void> {
-  const { jsonEnabled, executable } = options;
+  const { jsonEnabled, jitPlugin, executable } = options;
   const ux = new Ux({ jsonEnabled });
 
   const tmpDir = path.join(os.tmpdir(), 'sf-jit-test');
@@ -39,7 +40,7 @@ export async function testJITInstall(options: Options): Promise<void> {
 
   const fileData = await fs.promises.readFile('package.json', 'utf8');
   const packageJson = parseJson(fileData) as PackageJson;
-  const jitPlugins = Object.keys(packageJson.oclif?.jitPlugins ?? {});
+  const jitPlugins = jitPlugin ?? Object.keys(packageJson.oclif?.jitPlugins ?? {});
   if (jitPlugins.length === 0) return;
 
   let manifestData;

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -22,7 +22,7 @@ const exec = promisify(execSync);
 
 type Options = {
   jsonEnabled: boolean;
-  jitPlugin?: string[] | undefined;
+  jitPlugin?: string[];
   executable: string;
   manifestPath?: string;
 };


### PR DESCRIPTION
### What does this PR do?
Adds `--jit-plugin` flag to specify which tests you want to test the install

QA:
- Pull branch
- `yarn build`
- cd to your local `cli` (sf) dir
- Run `../plugin-release-management/bin/run cli:install:jit:test --jit-plugin "@salesforce/plugin-community" -j @salesforce/plugin-env`
- Confirm that only those two plugins are tested
- Confirm files exist at `ls -lah $TMPDIR/sf-jit-test/@salesforce`
- Next run without the flag, and make sure all plugins install.

### What issues does this PR fix or reference?
[@W-14169311@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14169311)