### PR TITLE
fix: support bin/run.js

### DIFF
--- a/src/commands/cli/release/build.ts
+++ b/src/commands/cli/release/build.ts
@@ -189,7 +189,8 @@ export default class build extends SfCommand<void> {
     await this.exec('npx yarn-deduplicate');
     // Run an install with deduplicated dependencies (with scripts)
     await this.exec('yarn install');
-    // Generate a new readme with the latest dependencies
+    // Generate a new readme with the latest dependencies. Requires source to be compiled.
+    await this.exec('yarn compile');
     await this.exec(
       'yarn oclif readme --no-aliases --repository-prefix "<%- repo %>/blob/<%- version %>/<%- commandPath %>"'
     );

--- a/src/commands/cli/release/build.ts
+++ b/src/commands/cli/release/build.ts
@@ -189,8 +189,7 @@ export default class build extends SfCommand<void> {
     await this.exec('npx yarn-deduplicate');
     // Run an install with deduplicated dependencies (with scripts)
     await this.exec('yarn install');
-    // Generate a new readme with the latest dependencies. Requires source to be compiled.
-    await this.exec('yarn compile');
+    // Generate a new readme with the latest dependencies.
     await this.exec(
       'yarn oclif readme --no-aliases --repository-prefix "<%- repo %>/blob/<%- version %>/<%- commandPath %>"'
     );

--- a/src/jit.ts
+++ b/src/jit.ts
@@ -27,9 +27,26 @@ type Options = {
   manifestPath?: string;
 };
 
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function testJITInstall(options: Options): Promise<void> {
-  const { jsonEnabled, jitPlugin, executable } = options;
+  const { jsonEnabled, jitPlugin } = options;
+  let { executable } = options;
   const ux = new Ux({ jsonEnabled });
+
+  if (executable.endsWith('run') && !(await exists(executable))) {
+    // This is a workaround for the ESM branch of sf.
+    // If the executable is bin/run but it doesn't exist, that likely means
+    // that bin/run.js is the executable.
+    executable += '.js';
+  }
 
   const tmpDir = path.join(os.tmpdir(), 'sf-jit-test');
   // Clear tmp dir before test to ensure that we're starting from a clean slate


### PR DESCRIPTION
### What does this PR do?

- Use `bin/run.js` for JIT test if `bin/run` doesn't exist

### What issues does this PR fix or reference?
[skip-validate-pr]