### PR TITLE
fix: safely fail package.json revert

### DIFF
--- a/src/codeSigning/packAndSign.ts
+++ b/src/codeSigning/packAndSign.ts
@@ -193,11 +193,15 @@ export const api = {
   },
 
   async revertPackageJsonIfExists(): Promise<void> {
-    // Restore the package.json file so it doesn't show a git diff.
-    await fs.access(pathGetter.packageJsonBak);
-    cliUx.log(`Restoring package.json from ${pathGetter.packageJsonBak}`);
-    await api.copyPackageDotJson(pathGetter.packageJsonBak, pathGetter.packageJson);
-    await fs.unlink(pathGetter.packageJsonBak);
+    try {
+      // Restore the package.json file so it doesn't show a git diff.
+      await fs.access(pathGetter.packageJsonBak);
+      cliUx.log(`Restoring package.json from ${pathGetter.packageJsonBak}`);
+      await api.copyPackageDotJson(pathGetter.packageJsonBak, pathGetter.packageJson);
+      await fs.unlink(pathGetter.packageJsonBak);
+    } catch {
+      // It's okay that the backup doesn't exist - do nothing
+    }
   },
   /**
    * main method to pack and sign an npm.


### PR DESCRIPTION
### What does this PR do?

Safely fail `revertPackageJsonIfExists` in `packageAndSign.ts` if the backup package.json doesn't exist (which was the [original design](https://github.com/salesforcecli/plugin-release-management/commit/99b534e3ac3278e19cbbe8928ed917f95168160c#diff-d51f800de2ce90f984d5fc649ca4433587383e05c86e0a6f60732e7ab56076aaL203)). Fixes issue with [failing publishes](https://github.com/salesforcecli/plugin-apex/actions/runs/8250889022/job/22566653180).

### What issues does this PR fix or reference?
[skip-validate-pr]