### PR TITLE
feat: handle non-json from npm view

### DIFF
--- a/src/commands/cli/artifacts/compare.ts
+++ b/src/commands/cli/artifacts/compare.ts
@@ -30,7 +30,13 @@ const messages = Messages.loadMessages('@salesforce/plugin-release-management', 
 async function getOwnerAndRepo(plugin: string): Promise<{ owner: string; repo: string }> {
   const result = await exec(`npm view ${plugin} repository.url --json`);
   try {
-    const [owner, repo] = (JSON.parse(result.stdout) as string)
+    const [owner, repo] = (
+      result.stdout.startsWith('"')
+        ? // it returned json (a string in quotes ex: "git+https://github.com/salesforcecli/plugin-org.git")
+          (JSON.parse(result.stdout) as string)
+        : // it returned non-json (just the string)
+          result.stdout
+    )
       .replace('git+https://github.com/', '')
       .replace('.git', '')
       .split('/');

--- a/src/commands/cli/artifacts/compare.ts
+++ b/src/commands/cli/artifacts/compare.ts
@@ -34,7 +34,7 @@ async function getOwnerAndRepo(plugin: string): Promise<{ owner: string; repo: s
       result.stdout.startsWith('"')
         ? // it returned json (a string in quotes ex: "git+https://github.com/salesforcecli/plugin-org.git")
           (JSON.parse(result.stdout) as string)
-        : // it returned non-json (just the string) https://github.com/npm/cli/issues/5444
+        : // it returned non-json (just the string) https://github.com/npm/cli/issues/7537
           result.stdout
     )
       .replace('git+https://github.com/', '')

--- a/src/commands/cli/artifacts/compare.ts
+++ b/src/commands/cli/artifacts/compare.ts
@@ -34,7 +34,7 @@ async function getOwnerAndRepo(plugin: string): Promise<{ owner: string; repo: s
       result.stdout.startsWith('"')
         ? // it returned json (a string in quotes ex: "git+https://github.com/salesforcecli/plugin-org.git")
           (JSON.parse(result.stdout) as string)
-        : // it returned non-json (just the string)
+        : // it returned non-json (just the string) https://github.com/npm/cli/issues/5444
           result.stdout
     )
       .replace('git+https://github.com/', '')


### PR DESCRIPTION
### What does this PR do?
becasue of https://github.com/npm/cli/issues/7537
handle both json and non-json responses for npm view 

### What issues does this PR fix or reference?
https://github.com/salesforcecli/cli/actions/runs/9289440974/job/25563341138?pr=1695