### PR TITLE
Removes `sfdx` from the cli:version:inspect command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -113,7 +113,7 @@
     "command": "cli:versions:inspect",
     "flagAliases": [],
     "flagChars": ["c", "d", "l", "s"],
-    "flags": ["channels", "cli", "dependencies", "flags-dir", "json", "locations", "salesforce"],
+    "flags": ["channels", "dependencies", "flags-dir", "ignore-missing", "json", "locations", "salesforce"],
     "plugin": "@salesforce/plugin-release-management"
   },
   {

--- a/messages/cli.versions.inspect.md
+++ b/messages/cli.versions.inspect.md
@@ -18,6 +18,10 @@ the channel you want to inspect (for achives, latest and latest-rc are translate
 
 the location you want to inspect
 
+# flags.ignoreMissing.summary
+
+skip missing archives. Useful when supporting new architectures in oclif
+
 # flags.cli.summary
 
 the CLI you want to inspect

--- a/schemas/cli-versions-inspect.json
+++ b/schemas/cli-versions-inspect.json
@@ -35,7 +35,7 @@
     },
     "Channel": {
       "type": "string",
-      "enum": ["legacy", "stable", "stable-rc", "latest", "latest-rc", "nightly"]
+      "enum": ["stable", "stable-rc", "latest", "latest-rc", "nightly"]
     },
     "Location": {
       "type": "string",

--- a/src/codeSigning/SimplifiedSigning.ts
+++ b/src/codeSigning/SimplifiedSigning.ts
@@ -40,7 +40,7 @@ type SigningRequest = {
   packageVersion: string;
   /** if true, uploads the signature and key file to AWS */
   upload: boolean;
-}
+};
 
 export type SigningResponse = {
   publicKeyContents: string;
@@ -58,12 +58,12 @@ export type SigningResponse = {
   packageName: string;
   /** npm version, like 1.0.0 */
   packageVersion: string;
-}
+};
 
 type KeyPair = {
   publicKey: string;
   privateKey: string;
-}
+};
 
 export const getSfdxProperty = (packageName: string, packageVersion: string): PackageJsonSfdxProperty => {
   const fullPathNoExtension = `${BASE_URL}/${SECURITY_PATH}/${packageName}/${packageVersion}`;

--- a/src/commands/dependabot/automerge.ts
+++ b/src/commands/dependabot/automerge.ts
@@ -32,7 +32,7 @@ type PullRequest = {
     sha: string;
     ref: string;
   };
-}
+};
 
 type octokitOpts = {
   owner: string;

--- a/src/package.ts
+++ b/src/package.ts
@@ -57,19 +57,19 @@ export type VersionValidation = {
   currentVersion: string;
   valid: boolean;
   name: string;
-}
+};
 
 type PinnedPackage = {
   name: string;
   version: string;
   tag: string;
-}
+};
 
 type DependencyInfo = {
   packageName: string;
   currentVersion?: string;
   finalVersion?: string;
-}
+};
 
 export function parsePackageVersion(alias: string): string | undefined {
   const regex = /[0-9]{1,3}(?:.[0-9]{1,3})?(?:.[0-9]{1,3})?(.*?)$/;


### PR DESCRIPTION
### What does this PR do?
Removes `sfdx` from the cli:version:inspect command
Other cleanup to remove complexity

Example of this skipping non-existing tarballs:
<img width="2186" alt="Screenshot 2024-10-11 at 11 13 43 AM" src="https://github.com/user-attachments/assets/5233e202-ef84-4586-987c-4d0800c04689">

Testing:
- pull branch
- yarn build
- Run the same command we use during promotions [here](https://github.com/salesforcecli/cli/blob/e86babd2842de2bc55c4123833185db6e94f4b51/.github/workflows/promote-rc-to-latest.yml#L56)
  - `bin/run.js cli:versions:inspect -c stable-rc -l archive`
- You can run it with `npm` also if you want 
  - `bin/run.js cli:versions:inspect -c stable-rc -l archive -l npm`


NOTE: I did not look at any of the "dependency" listing code. That was out of scope for this.

### What issues does this PR fix or reference?
[@W-16893140@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16893140)