### PR TITLE
fix: use transformToString() to read S3 getObject Body in channel:promote

### DIFF
--- a/src/commands/channel/promote.ts
+++ b/src/commands/channel/promote.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { Readable } from 'node:stream';
 import chalk from 'chalk';
 import { valid as validSemVer } from 'semver';
 import { Interfaces } from '@oclif/core';
@@ -12,6 +13,7 @@ import shelljs from 'shelljs';
 import { Logger, Messages, SfError } from '@salesforce/core';
 import { ensureString, isString } from '@salesforce/ts-types';
 import { SfCommand, Flags, arrayWithDeprecation } from '@salesforce/sf-plugins-core';
+import { SdkStream } from '@smithy/types';
 import { AmazonS3 } from '../../amazonS3.js';
 import { verifyDependencies } from '../../dependencies.js';
 import { CLI, Channel, S3Manifest, VersionShaContents } from '../../types.js';
@@ -309,9 +311,7 @@ const findShaForVersion = async (cli: CLI, version: string): Promise<string> => 
           `Could not load manifest body from S3 getObject response for ${manifestForMostRecentSha.Key}`
         );
       }
-      const json = JSON.parse(
-        await (manifest.Body as unknown as { transformToString(): Promise<string> }).transformToString()
-      ) as S3Manifest;
+      const json = JSON.parse(await (manifest.Body as SdkStream<Readable>).transformToString()) as S3Manifest;
       return json.sha;
     }
   }

--- a/src/commands/channel/promote.ts
+++ b/src/commands/channel/promote.ts
@@ -309,8 +309,9 @@ const findShaForVersion = async (cli: CLI, version: string): Promise<string> => 
           `Could not load manifest body from S3 getObject response for ${manifestForMostRecentSha.Key}`
         );
       }
-      logger.debug(`Loaded manifest ${manifestForMostRecentSha.Key} contents: ${String(manifest)}`);
-      const json = JSON.parse(String(manifest.Body)) as S3Manifest;
+      const json = JSON.parse(
+        await (manifest.Body as unknown as { transformToString(): Promise<string> }).transformToString()
+      ) as S3Manifest;
       return json.sha;
     }
   }


### PR DESCRIPTION
## Summary
- `channel:promote` was failing with `"[object Object]" is not valid JSON` since the AWS SDK v2 → v3 migration (`929dabf`)
- SDK v2 returned `Body` as a `Buffer` — `toString()` worked; SDK v3 returns it as a `SdkStreamMixin` stream — `String(body)` yields `[object Object]`
- Fix: use `transformToString()`, the documented SDK v3 API for consuming the stream

## Root cause
The bug was introduced in `929dabf` (SDK v3 migration) but was dormant because `salesforcecli/cli` was pinned to `^5.7.0` (pre-migration). It surfaced when `2.132.2` bumped PRM to `^5.8.6`.

## Test plan
- [ ] `node -e "import('./lib/amazonS3.js')"` smoke test passes locally (verified)
- [ ] `channel:promote` CI job passes in `salesforcecli/cli`